### PR TITLE
 Layout System Changes

### DIFF
--- a/internal/tui/app/commands.go
+++ b/internal/tui/app/commands.go
@@ -14,15 +14,15 @@ func (m Model) getMergeRequestModel(msg task.TaskMsg) func() table.Model {
 	return func() table.Model {
 		mrMsg := msg.Msg.(message.MergeRequestsListFetchedMsg)
 		rows := mergerequests.GetTableRows(mrMsg)
-		mainPanelHeaderHeight := 1
+		tableW := m.layout.MainPanel.Width - table.DocStyle.GetHorizontalFrameSize() - tableBorderX
 		return table.InitModel(table.InitModelParams{
 			Rows:   rows,
-			Colums: mergerequests.GetTableColums(m.ctx.Window.Width),
+			Colums: mergerequests.GetTableColums(tableW),
 			StyleFunc: table.StyleIconsColumns(
 				table.Styles(table.DefaultStyle()),
 				mergerequests.IconCols(),
 			),
-			Height: m.ctx.PanelHeight - mainPanelHeaderHeight,
+			Height: m.layout.ContentH - mainPanelHeaderLines - tableBorderY - tableViewOverhead,
 		})
 	}
 }
@@ -59,19 +59,4 @@ func (m *Model) openInBrowser() {
 	colIdx := mergerequests.GetColIndex(mergerequests.ColNames.URL)
 	url := m.MergeRequests.Table.SelectedRow()[colIdx]
 	exec.Openbrowser(url)
-}
-
-func (m *Model) resizeTable(msg tea.WindowSizeMsg) table.Model {
-	m.MergeRequests.Table.SetWidth(msg.Width)
-	mainPanelHeaderHeight := 1
-
-	return table.InitModel(table.InitModelParams{
-		Rows:   m.MergeRequests.Table.Rows(),
-		Colums: mergerequests.GetTableColums(m.ctx.Window.Width),
-		StyleFunc: table.StyleIconsColumns(
-			table.Styles(table.DefaultStyle()),
-			mergerequests.IconCols(),
-		),
-		Height: m.ctx.PanelHeight - mainPanelHeaderHeight,
-	})
 }

--- a/internal/tui/app/layout.go
+++ b/internal/tui/app/layout.go
@@ -1,0 +1,113 @@
+package app
+
+import (
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/felipeospina21/mrglab/internal/tui/components/details"
+	"github.com/felipeospina21/mrglab/internal/tui/components/mergerequests"
+	"github.com/felipeospina21/mrglab/internal/tui/components/projects"
+	"github.com/felipeospina21/mrglab/internal/tui/components/statusline"
+	"github.com/felipeospina21/mrglab/internal/tui/components/table"
+	"github.com/felipeospina21/mrglab/internal/tui/style"
+)
+
+// PanelSize holds the computed width and height for a UI region.
+type PanelSize struct {
+	Width  int
+	Height int
+}
+
+// Layout holds all computed dimensions for the current window size and panel state.
+// Computed once on WindowSizeMsg or panel toggle, then consumed by View and applyLayout.
+type Layout struct {
+	Window     tea.WindowSizeMsg
+	LeftPanel  PanelSize
+	MainPanel  PanelSize
+	RightPanel PanelSize
+	Statusline PanelSize
+	ContentH   int // usable content height (window minus main frame minus statusline)
+}
+
+const (
+	leftPanelWidth       = 30 // matches projects.DocStyle.Width(30)
+	mainPanelHeaderLines = 1  // the "Project - Merge Requests" header
+	statuslineLines      = 1  // statusline is a single rendered line
+
+	// table.DocStyle uses BorderStyle(RoundedBorder()) which renders borders
+	// but lipgloss GetFrameSize() reports 0 for it. Account for the actual rendered border.
+	tableBorderX = 2
+	tableBorderY = 2
+
+	// table.View() renders 1 line taller than SetHeight due to headersView()
+	// border bottom not being counted by lipgloss.Height() inside SetHeight.
+	tableViewOverhead = 1
+)
+
+func computeLayout(win tea.WindowSizeMsg, leftOpen, rightOpen bool) Layout {
+	mainFrameX, mainFrameY := style.MainFrameStyle.GetFrameSize()
+
+	innerW := win.Width - mainFrameX
+	innerH := win.Height - mainFrameY
+
+	// Statusline: full inner width, fixed height
+	slFrameY := statusline.StatusBarStyle.GetVerticalFrameSize()
+	slH := statuslineLines + slFrameY
+	slFrameX := statusline.StatusBarStyle.GetHorizontalFrameSize()
+
+	contentH := innerH - slH
+
+	// Left panel
+	leftW := 0
+	if leftOpen {
+		leftW = leftPanelWidth + projects.DocStyle.GetHorizontalFrameSize()
+	}
+
+	// Main panel gets remaining width, minus right panel if open
+	mainW := innerW - leftW
+	rightW := 0
+	if rightOpen && !leftOpen {
+		detailsFrameX := details.PanelStyle.GetHorizontalFrameSize()
+		rightW = mainW/2 - detailsFrameX
+		mainW = mainW - rightW - detailsFrameX
+	}
+
+	// Left panel: subtract DocStyle vertical frame (MarginBottom:2) so rendered output fits
+	leftH := contentH - projects.DocStyle.GetVerticalFrameSize()
+
+	return Layout{
+		Window:     win,
+		LeftPanel:  PanelSize{Width: leftW, Height: leftH},
+		MainPanel:  PanelSize{Width: mainW, Height: contentH},
+		RightPanel: PanelSize{Width: rightW, Height: contentH},
+		Statusline: PanelSize{Width: innerW - slFrameX, Height: slH},
+		ContentH:   contentH,
+	}
+}
+
+// applyLayout pushes the computed dimensions to all components in-place.
+func (m *Model) applyLayout() {
+	l := m.layout
+
+	// Left panel
+	m.Projects.List.SetHeight(l.LeftPanel.Height)
+	m.ctx.PanelHeight = l.ContentH
+
+	// Statusline
+	m.Statusline.Width = l.Statusline.Width
+
+	// Main panel table — update in-place instead of reconstructing
+	if len(m.MergeRequests.Table.Rows()) > 0 {
+		tableFrameX := table.DocStyle.GetHorizontalFrameSize() + tableBorderX
+		tableW := l.MainPanel.Width - tableFrameX
+		m.MergeRequests.Table.SetWidth(tableW)
+		m.MergeRequests.Table.SetHeight(l.ContentH - mainPanelHeaderLines - tableBorderY - tableViewOverhead)
+		m.MergeRequests.Table.SetColumns(mergerequests.GetTableColums(tableW))
+	}
+
+	// Right panel (details viewport)
+	if m.ctx.IsRightPanelOpen {
+		detailsFrameY := details.PanelStyle.GetVerticalFrameSize()
+		m.Details.SetViewportViewSize(
+			tea.WindowSizeMsg{Width: l.RightPanel.Width, Height: l.ContentH - detailsFrameY - tableViewOverhead},
+		)
+	}
+}

--- a/internal/tui/app/model.go
+++ b/internal/tui/app/model.go
@@ -4,7 +4,6 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 	"github.com/felipeospina21/mrglab/internal/config"
 	"github.com/felipeospina21/mrglab/internal/context"
 	"github.com/felipeospina21/mrglab/internal/tui/components/details"
@@ -13,8 +12,6 @@ import (
 	"github.com/felipeospina21/mrglab/internal/tui/components/modal"
 	"github.com/felipeospina21/mrglab/internal/tui/components/projects"
 	"github.com/felipeospina21/mrglab/internal/tui/components/statusline"
-	"github.com/felipeospina21/mrglab/internal/tui/components/table"
-	"github.com/felipeospina21/mrglab/internal/tui/style"
 	"github.com/felipeospina21/mrglab/internal/tui/task"
 )
 
@@ -26,6 +23,7 @@ type Model struct {
 	Modal         modal.Model
 	Spinner       spinner.Model
 	Input         textarea.Model
+	layout        Layout
 	ctx           *context.AppContext
 }
 
@@ -75,7 +73,6 @@ func (m *Model) setStatus(mode string, content string) {
 func (m *Model) startTask(cb func() tea.Cmd) tea.Cmd {
 	m.ctx.Task.Status = task.TaskStarted
 	m.setStatus(statusline.ModesEnum.Loading, m.Statusline.Spinner.View())
-	// m.startTask()
 	return cb()
 }
 
@@ -108,59 +105,21 @@ func (m *Model) updateSpinnerViewCommand(msg tea.Msg) tea.Cmd {
 
 func (m *Model) toggleLeftPanel() {
 	m.ctx.IsLeftPanelOpen = !m.ctx.IsLeftPanelOpen
-	m.MergeRequests.Table.SetWidth(lipgloss.Width(m.MergeRequests.Table.View()))
+	m.recomputeLayout()
 }
 
 func (m *Model) toggleRightPanel() {
 	m.ctx.IsRightPanelOpen = !m.ctx.IsRightPanelOpen
-	m.MergeRequests.Table.SetWidth(lipgloss.Width(m.MergeRequests.Table.View()))
-	m.MergeRequests.Table.UpdateViewport()
+	m.recomputeLayout()
+}
+
+func (m *Model) recomputeLayout() {
+	m.layout = computeLayout(m.ctx.Window, m.ctx.IsLeftPanelOpen, m.ctx.IsRightPanelOpen)
+	m.applyLayout()
 }
 
 func (m *Model) setHelpKeys(kb help.KeyMap) {
 	m.ctx.Keybinds = kb
-}
-
-func getFrameSize() (int, int) {
-	xMain, yMain := style.MainFrameStyle.GetFrameSize()
-	xProjects, yProjects := projects.GetFrameSize()
-	xStatus, yStatus := statusline.GetFrameSize()
-
-	return xMain + xProjects + xStatus, yMain + yProjects + yStatus
-}
-
-func (m Model) getEmptyTableSize() (int, int) {
-	w, h := m.ctx.Window.Width, m.ctx.Window.Height
-	leftPanX, leftPanY := projects.GetFrameSize()
-	leftPanW := m.Projects.List.Width()
-	tableX := table.TitleStyle.GetHorizontalFrameSize()
-	statusHeight := lipgloss.Height(m.Statusline.View())
-
-	width := w - leftPanX - leftPanW - tableX
-	height := h - leftPanY - statusHeight - style.MainFrameStyle.GetVerticalFrameSize()
-
-	return width, height
-}
-
-func (m *Model) setLeftPanelHeight() {
-	_, y := getFrameSize()
-	yStatus := lipgloss.Height(m.Statusline.View())
-	height := m.ctx.Window.Height - y - yStatus - 3 // FIX: find how to replace this magic num
-
-	m.Projects.List.SetHeight(height)
-	m.ctx.PanelHeight = height
-}
-
-func (m *Model) setStatuslineWidth() {
-	windowW := m.ctx.Window.Width
-	xStatus, _ := statusline.GetFrameSize()
-	m.Statusline.Width = windowW - xStatus
-}
-
-func (m Model) getViewportViewWidth() int {
-	_, xFrame := getFrameSize()
-	panelFrame := details.PanelStyle.GetHorizontalFrameSize()
-	return m.ctx.Window.Width - lipgloss.Width(m.MergeRequests.Table.View()) - xFrame - panelFrame
 }
 
 func (m *Model) SelectMR() {

--- a/internal/tui/app/update.go
+++ b/internal/tui/app/update.go
@@ -124,12 +124,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.MergeRequests.Table, cmd = m.MergeRequests.Table.Update(msg)
 			switch {
 			case match(mpk.Details):
-				resizeCmd := m.Details.SetViewportViewSize(
-					tea.WindowSizeMsg{Width: m.getViewportViewWidth(), Height: m.ctx.PanelHeight},
-				)
-
 				cmds = append(cmds,
-					resizeCmd,
 					m.startTask(m.fetchSingleMergeRequest),
 				)
 
@@ -171,15 +166,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmds = append(cmds, cmd, spin)
 
 	case tea.WindowSizeMsg:
-		// Sets window in context
 		m.ctx.Window = msg
-
-		m.setLeftPanelHeight()
-		m.setStatuslineWidth()
-
-		if len(m.MergeRequests.Table.Rows()) > 0 {
-			m.MergeRequests.Table = m.resizeTable(msg)
-		}
+		m.recomputeLayout()
 
 	case task.TaskMsg:
 		if msg.Err != nil {
@@ -224,6 +212,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// get description
 				idx := mergerequests.GetColIndex(mergerequests.ColNames.Description)
 				d := m.MergeRequests.Table.SelectedRow()[idx]
+				// Size viewport before setting content so glamour uses correct width
+				rl := computeLayout(m.ctx.Window, false, true)
+				m.Details.SetViewportViewSize(
+					tea.WindowSizeMsg{Width: rl.RightPanel.Width, Height: rl.ContentH - details.PanelStyle.GetVerticalFrameSize() - tableViewOverhead},
+				)
+
 				c := m.Details.GetViewportContent(d, details.MergeRequestDetails(mr))
 				m.Details.Viewport.SetContent(c)
 

--- a/internal/tui/app/update.go
+++ b/internal/tui/app/update.go
@@ -192,6 +192,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						m.MergeRequests.SetFocus()
 					}
 					m.MergeRequests.Table = t
+					m.recomputeLayout()
 				}
 
 			}

--- a/internal/tui/app/view.go
+++ b/internal/tui/app/view.go
@@ -23,11 +23,12 @@ func (m Model) View() string {
 			body := lipgloss.JoinHorizontal(0, left, m.ctx.Task.Err.Error())
 			sl := m.Statusline.View()
 			return render(lipgloss.JoinVertical(0, body, sl))
-
 		}
 
-		m.MergeRequests.Table.W, m.MergeRequests.Table.H = m.getEmptyTableSize()
-		body := lipgloss.JoinHorizontal(0, left, table.DocStyle.Render(m.MergeRequests.Table.View()))
+		m.MergeRequests.Table.W = m.layout.MainPanel.Width - table.DocStyle.GetHorizontalFrameSize() - tableBorderX
+		m.MergeRequests.Table.H = m.layout.MainPanel.Height - tableBorderY
+		tbl := table.DocStyle.Render(m.MergeRequests.Table.View())
+		body := lipgloss.JoinHorizontal(0, left, tbl)
 		sl := m.Statusline.View()
 		return render(lipgloss.JoinVertical(0, body, sl))
 
@@ -52,7 +53,6 @@ func (m Model) View() string {
 			main := lipgloss.JoinHorizontal(0, left, body)
 			sl := m.Statusline.View()
 			return render(lipgloss.JoinVertical(0, main, sl))
-
 		}
 
 		if m.ctx.IsRightPanelOpen {
@@ -70,8 +70,14 @@ func (m Model) getMainPanelComponents() (string, string) {
 		fmt.Sprintf("%s - %s", m.ctx.SelectedProject.Name, "Merge Requests"),
 	)
 	body := lipgloss.JoinVertical(0, header, table.DocStyle.Render(m.MergeRequests.Table.View()))
-	h := m.ctx.Window.Height - lipgloss.Height(body) - style.MainFrameStyle.GetVerticalFrameSize()
-	statusline := lipgloss.PlaceVertical(h, lipgloss.Bottom, m.Statusline.View())
+
+	bodyHeight := lipgloss.Height(body)
+	innerH := m.ctx.Window.Height - style.MainFrameStyle.GetVerticalFrameSize()
+	remainingH := innerH - bodyHeight
+	if remainingH < m.layout.Statusline.Height {
+		remainingH = m.layout.Statusline.Height
+	}
+	statusline := lipgloss.PlaceVertical(remainingH, lipgloss.Bottom, m.Statusline.View())
 
 	return body, statusline
 }

--- a/internal/tui/components/mergerequests/mergerequests.go
+++ b/internal/tui/components/mergerequests/mergerequests.go
@@ -67,7 +67,7 @@ var Cols = []table.Column{
 	{
 		Name:  ColNames.Title,
 		Title: "Title",
-		Width: 25,
+		Width: 64,
 	},
 	{
 		Name:  ColNames.Author,
@@ -157,9 +157,26 @@ func (m *Model) SetFocus() {
 func GetTableColums(width int) []table.Column {
 	w := table.ColWidth
 	columns := []table.Column{}
+	visibleCount := 0
 	for _, col := range Cols {
-		col.Width = w(width, col.Width)
+		if col.Width > 0 {
+			visibleCount++
+		}
+	}
+	// Each visible cell has Padding(0,1) = 2 chars not included in col.Width
+	contentWidth := width - visibleCount*2
+	used := 0
+	titleIdx := -1
+	for i, col := range Cols {
+		col.Width = w(contentWidth, col.Width)
+		if col.Name == ColNames.Title {
+			titleIdx = i
+		}
+		used += col.Width
 		columns = append(columns, table.Column(col))
+	}
+	if titleIdx >= 0 {
+		columns[titleIdx].Width += contentWidth - used
 	}
 	return columns
 }

--- a/internal/tui/components/projects/projects.go
+++ b/internal/tui/components/projects/projects.go
@@ -75,7 +75,7 @@ type itemDelegate struct {
 	Styles          DefaultItemStyles
 }
 
-func (d itemDelegate) Height() int                             { return 1 }
+func (d itemDelegate) Height() int                             { return 2 }
 func (d itemDelegate) Spacing() int                            { return 0 }
 func (d itemDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
 


### PR DESCRIPTION
# Layout System Changes

## Summary

Replaced scattered, fragile sizing calculations with a centralized layout system in `internal/tui/app/layout.go`. All panel dimensions are now computed once on `WindowSizeMsg` or panel toggle, then pushed to components via `applyLayout()`.

## New File

### `internal/tui/app/layout.go`
- `PanelSize` struct (Width, Height)
- `Layout` struct holding computed dimensions for all panels, statusline, and usable content height
- `computeLayout(win, leftOpen, rightOpen)` — single top-down calculation
- `applyLayout()` — pushes sizes to all components in-place
- Constants documenting the magic numbers: `leftPanelWidth`, `mainPanelHeaderLines`, `statuslineLines`, `tableBorderX/Y`, `tableViewOverhead`

## Modified Files

### `internal/tui/app/model.go`
- Added `layout Layout` field to `Model`
- Added `recomputeLayout()` helper (calls `computeLayout` + `applyLayout`)
- Simplified `toggleLeftPanel()` / `toggleRightPanel()` to just toggle state and call `recomputeLayout()`
- Removed: `getFrameSize()`, `getEmptyTableSize()`, `setLeftPanelHeight()`, `setStatuslineWidth()`, `getViewportViewWidth()`

### `internal/tui/app/update.go`
- `WindowSizeMsg` handler reduced to `m.ctx.Window = msg; m.recomputeLayout()`
- Details key handler: pre-computes layout with right panel open to size the viewport before content is fetched
- Removed manual `SetViewportViewSize` and `resizeTable` calls

### `internal/tui/app/commands.go`
- `getMergeRequestModel` uses `m.layout` dimensions for initial table creation
- Removed `resizeTable()` entirely — `applyLayout` handles resize

### `internal/tui/app/view.go`
- Initial screen uses `m.layout.MainPanel` for empty table sizing
- Right panel path: `JoinHorizontal(body, right)` then `JoinVertical(main, sl)` so statusline spans full width
- Statusline placement uses `innerH - bodyHeight` for correct gap filling

### `internal/tui/components/projects/projects.go`
- Fixed `itemDelegate.Height()`: changed from `1` to `2` to match actual rendered output (title + description). The mismatch caused the bubbletea list to render more lines than `SetHeight` allocated.

## Bugs Fixed

### List header clipped
The bubbletea list delegate returned `Height() = 1` but rendered 2 lines per item (`title\ndesc`). The list component used `Height()` to calculate how many items fit, so it rendered 5 extra lines beyond `SetHeight`, overflowing the frame.

### Table top border missing
Two compounding issues:
1. `table.DocStyle` uses `BorderStyle(lipgloss.RoundedBorder())` which renders borders (+2 vertical, +2 horizontal) but lipgloss `GetFrameSize()` reports 0 — the `BorderStyle` setter doesn't enable `GetBorder*()` accessors. Accounted for via `tableBorderX/Y` constants.
2. The table's `SetHeight(h)` subtracts `lipgloss.Height(headersView())` for the viewport, but `headersView()` renders a border-bottom line that `lipgloss.Height()` doesn't count (each column header styled individually, then joined). This causes `View()` to be 1 line taller than `SetHeight`. Accounted for via `tableViewOverhead` constant.

### Details panel not visible
The statusline (full window width) was joined vertically with the table body before joining horizontally with the details panel. This made the left column 379 chars wide, pushing the 189-char details panel off-screen (total 568 > terminal 381). Fixed by joining body+right horizontally first, then statusline below both.

### Details panel content empty on open
The old code sized the viewport in the Details key handler before fetching. The layout refactor removed that call. Restored by pre-computing the layout with `rightOpen=true` and sizing the viewport right before `SetContent` in the task handler.

## Key Design Decisions

- **Constants over `GetFrameSize()`**: Where lipgloss reports incorrect frame sizes (table DocStyle border, table view overhead), explicit constants document the actual values.
- **`projects.DocStyle.GetVerticalFrameSize()`** is subtracted from left panel height since the list's `SetHeight` controls content lines but `DocStyle.Render()` adds MarginBottom(2).
- **`getMainPanelComponents`** uses `innerH - bodyHeight` for statusline placement to fill the frame exactly regardless of table overhead.
