### PR TITLE
update config so its not global

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -39,6 +39,7 @@ type AppContext struct {
 	IsLeftPanelOpen  bool
 	IsRightPanelOpen bool
 	IsModalOpen      bool
+	DevMode          bool
 	FocusedPanel     focusedPanel
 	PanelHeight      int
 }

--- a/internal/tui/app/model.go
+++ b/internal/tui/app/model.go
@@ -27,13 +27,14 @@ type Model struct {
 	ctx           *context.AppContext
 }
 
-func InitMainModel(ctx *context.AppContext, client *gitlab.Client) Model {
+func InitMainModel(ctx *context.AppContext, cfg *config.Config, client *gitlab.Client) Model {
 	ctx.Keybinds = projects.Keybinds
 	ctx.FocusedPanel = context.LeftPanel
 	ctx.TaskStatus = context.TaskIdle
+	ctx.DevMode = cfg.DevMode
 
 	return Model{
-		Projects:      projects.New(ctx, client),
+		Projects:      projects.New(ctx, client, cfg.Filters.Projects),
 		MergeRequests: mergerequests.New(ctx, client),
 		Details:       details.New(ctx),
 		Statusline:    statusline.New(ctx),
@@ -80,7 +81,7 @@ func (m *Model) finishTask(err error, kb help.KeyMap) {
 		m.ctx.TaskErr = err
 	} else {
 		mode := statusline.ModesEnum.Normal
-		if config.GlobalConfig.DevMode {
+		if m.ctx.DevMode {
 			mode = statusline.ModesEnum.Dev
 		}
 		m.setStatus(mode, "")

--- a/internal/tui/app/update.go
+++ b/internal/tui/app/update.go
@@ -7,7 +7,6 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/charmbracelet/bubbles/spinner"
-	"github.com/felipeospina21/mrglab/internal/config"
 	"github.com/felipeospina21/mrglab/internal/context"
 	"github.com/felipeospina21/mrglab/internal/logger"
 	"github.com/felipeospina21/mrglab/internal/tui"
@@ -82,7 +81,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.Input.Blur()
 		if m.ctx.TaskErr != nil {
 			mode := statusline.ModesEnum.Normal
-			if config.GlobalConfig.DevMode {
+			if m.ctx.DevMode {
 				mode = statusline.ModesEnum.Dev
 			}
 			m.setStatus(mode, "")
@@ -168,7 +167,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m *Model) handleGlobalKeys(msg tea.KeyMsg) tea.Cmd {
 	match := tui.KeyMatcher(msg)
-	gk := tui.GlobalKeys()
+	gk := tui.GlobalKeys(m.ctx.DevMode)
 
 	switch {
 	case match(gk.MockFetch):

--- a/internal/tui/components/details/keys.go
+++ b/internal/tui/components/details/keys.go
@@ -46,5 +46,5 @@ var Keybinds = DetailsKeyMap{
 		key.WithKeys("x"),
 		key.WithHelp("x", "open in browser"),
 	),
-	GlobalKeyMap: tui.GlobalKeys(),
+	GlobalKeyMap: tui.GlobalKeys(false),
 }

--- a/internal/tui/components/mergerequests/keys.go
+++ b/internal/tui/components/mergerequests/keys.go
@@ -56,5 +56,5 @@ var Keybinds = MergeReqsKeyMap{
 		key.WithKeys("M"),
 		key.WithHelp("M", "merge MR"),
 	),
-	GlobalKeyMap: tui.GlobalKeys(),
+	GlobalKeyMap: tui.GlobalKeys(false),
 }

--- a/internal/tui/components/modal/keys.go
+++ b/internal/tui/components/modal/keys.go
@@ -27,5 +27,5 @@ var Keybinds = KeyMap{
 		key.WithKeys("esc"),
 		key.WithHelp("esc", "close modal"),
 	),
-	GlobalKeyMap: tui.GlobalKeys(),
+	GlobalKeyMap: tui.GlobalKeys(false),
 }

--- a/internal/tui/components/projects/keys.go
+++ b/internal/tui/components/projects/keys.go
@@ -26,5 +26,5 @@ var Keybinds = ProjectsKeyMap{
 		key.WithKeys("enter"),
 		key.WithHelp("enter", "view merge requests"),
 	),
-	GlobalKeyMap: tui.GlobalKeys(),
+	GlobalKeyMap: tui.GlobalKeys(false),
 }

--- a/internal/tui/components/projects/projects.go
+++ b/internal/tui/components/projects/projects.go
@@ -24,13 +24,11 @@ type Model struct {
 	client *gitlab.Client
 }
 
-func New(ctx *context.AppContext, client *gitlab.Client) Model {
-	projects := config.GlobalConfig.Filters.Projects
-
+func New(ctx *context.AppContext, client *gitlab.Client, projectList []config.Project) Model {
 	var li []list.Item
 	var i Item
 
-	for _, val := range projects {
+	for _, val := range projectList {
 		err := mapstructure.Decode(val, &i)
 		if err != nil {
 			fmt.Println("Error loading projects", err)

--- a/internal/tui/components/statusline/statusline.go
+++ b/internal/tui/components/statusline/statusline.go
@@ -6,7 +6,6 @@ import (
 	"github.com/charmbracelet/bubbles/spinner"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/felipeospina21/mrglab/internal/config"
 	"github.com/felipeospina21/mrglab/internal/context"
 	"github.com/felipeospina21/mrglab/internal/tui"
 	"github.com/felipeospina21/mrglab/internal/tui/components/help"
@@ -40,7 +39,7 @@ type Model struct {
 
 func New(ctx *context.AppContext) Model {
 	status := ModesEnum.Normal
-	if config.GlobalConfig.DevMode {
+	if ctx.DevMode {
 		status = ModesEnum.Dev
 	}
 	return Model{

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/felipeospina21/mrglab/internal/config"
 )
 
 type GlobalKeyMap struct {
@@ -16,7 +15,7 @@ type GlobalKeyMap struct {
 }
 
 var CommonKeys = []key.Binding{
-	GlobalKeys().ToggleLeftPanel, GlobalKeys().OpenModal, GlobalKeys().Help, GlobalKeys().Quit,
+	GlobalKeys(false).ToggleLeftPanel, GlobalKeys(false).OpenModal, GlobalKeys(false).Help, GlobalKeys(false).Quit,
 }
 
 func (k GlobalKeyMap) ShortHelp() []key.Binding {
@@ -29,8 +28,7 @@ func (k GlobalKeyMap) FullHelp() [][]key.Binding {
 	}
 }
 
-func GlobalKeys() GlobalKeyMap {
-	cfg := &config.GlobalConfig
+func GlobalKeys(devMode bool) GlobalKeyMap {
 	keymap := GlobalKeyMap{
 		Help: key.NewBinding(
 			key.WithKeys("?"),
@@ -50,7 +48,7 @@ func GlobalKeys() GlobalKeyMap {
 		),
 	}
 
-	if cfg.DevMode {
+	if devMode {
 		keymap.ThrowError = key.NewBinding(
 			key.WithKeys("E"),
 			key.WithHelp("E", "throw error"),

--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func main() {
 	}
 
 	client := gitlab.NewClient(&config.GlobalConfig)
-	m := app.InitMainModel(ctx, client)
+	m := app.InitMainModel(ctx, &config.GlobalConfig, client)
 
 	if _, err := tea.NewProgram(m, tea.WithAltScreen()).Run(); err != nil {
 		fmt.Println("Error running program:", err)


### PR DESCRIPTION
- Added DevMode bool to AppContext — set once in InitMainModel from cfg.DevMode
- projects.New() now takes []config.Project instead of reading config.GlobalConfig.Filters.Projects
- statusline.New() uses ctx.DevMode instead of config.GlobalConfig.DevMode
- tui.GlobalKeys(devMode bool) takes a param instead of reading the global. Package-level Keybinds vars pass false (dev keys are zero-value, never match
). handleGlobalKeys passes m.ctx.DevMode to get the real dev bindings
- app/model.go and app/update.go use m.ctx.DevMode instead of config.GlobalConfig.DevMode
- InitMainModel now accepts *config.Config and wires everything
- config.GlobalConfig is now only referenced in main.go — nowhere else in the codebase