### PR TITLE
trim app context

### DIFF
--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -1,9 +1,6 @@
 package context
 
-import (
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/felipeospina21/mrglab/internal/tui/components/help"
-)
+import tea "github.com/charmbracelet/bubbletea"
 
 type focusedPanel uint
 
@@ -12,14 +9,6 @@ const (
 	MainPanel
 	RightPanel
 	Modal
-)
-
-type TaskStatus uint
-
-const (
-	TaskIdle TaskStatus = iota
-	TaskStarted
-	TaskFinished
 )
 
 type AppContext struct {
@@ -32,14 +21,8 @@ type AppContext struct {
 		Sha    string
 		Status string
 	}
-	Window           tea.WindowSizeMsg
-	Keybinds         help.KeyMap
-	TaskStatus       TaskStatus
-	TaskErr          error
-	IsLeftPanelOpen  bool
-	IsRightPanelOpen bool
-	IsModalOpen      bool
-	DevMode          bool
-	FocusedPanel     focusedPanel
-	PanelHeight      int
+	Window       tea.WindowSizeMsg
+	DevMode      bool
+	FocusedPanel focusedPanel
+	PanelHeight  int
 }

--- a/internal/tui/app/layout.go
+++ b/internal/tui/app/layout.go
@@ -104,7 +104,7 @@ func (m *Model) applyLayout() {
 	}
 
 	// Right panel (details viewport)
-	if m.ctx.IsRightPanelOpen {
+	if m.isRightOpen {
 		detailsFrameY := details.PanelStyle.GetVerticalFrameSize()
 		m.Details.SetViewportViewSize(
 			tea.WindowSizeMsg{Width: l.RightPanel.Width, Height: l.ContentH - detailsFrameY - tableViewOverhead},

--- a/internal/tui/app/model.go
+++ b/internal/tui/app/model.go
@@ -15,6 +15,14 @@ import (
 	"github.com/felipeospina21/mrglab/internal/tui/components/statusline"
 )
 
+type taskStatus uint
+
+const (
+	taskIdle taskStatus = iota
+	taskStarted
+	taskFinished
+)
+
 type Model struct {
 	Projects      projects.Model
 	MergeRequests mergerequests.Model
@@ -25,25 +33,30 @@ type Model struct {
 	Input         textarea.Model
 	layout        Layout
 	ctx           *context.AppContext
+	taskStatus    taskStatus
+	taskErr       error
+	isLeftOpen    bool
+	isRightOpen   bool
+	isModalOpen   bool
 }
 
 func InitMainModel(ctx *context.AppContext, cfg *config.Config, client *gitlab.Client) Model {
-	ctx.Keybinds = projects.Keybinds
 	ctx.FocusedPanel = context.LeftPanel
-	ctx.TaskStatus = context.TaskIdle
 	ctx.DevMode = cfg.DevMode
 
 	return Model{
 		Projects:      projects.New(ctx, client, cfg.Filters.Projects),
 		MergeRequests: mergerequests.New(ctx, client),
 		Details:       details.New(ctx),
-		Statusline:    statusline.New(ctx),
+		Statusline:    statusline.New(ctx, projects.Keybinds),
 		Modal:         modal.New(ctx),
 		Spinner: spinner.New(
 			spinner.WithSpinner(spinner.Line),
 			spinner.WithStyle(statusline.SpinnerStyle),
 		),
-		ctx: ctx,
+		ctx:        ctx,
+		taskStatus: taskIdle,
+		isLeftOpen: true,
 	}
 }
 
@@ -70,7 +83,7 @@ func (m *Model) setStatus(mode string, content string) {
 }
 
 func (m *Model) startTask(cb func() tea.Cmd) tea.Cmd {
-	m.ctx.TaskStatus = context.TaskStarted
+	m.taskStatus = taskStarted
 	m.setStatus(statusline.ModesEnum.Loading, m.Statusline.Spinner.View())
 	return cb()
 }
@@ -78,7 +91,7 @@ func (m *Model) startTask(cb func() tea.Cmd) tea.Cmd {
 func (m *Model) finishTask(err error, kb help.KeyMap) {
 	if err != nil {
 		m.setStatus(statusline.ModesEnum.Error, err.Error())
-		m.ctx.TaskErr = err
+		m.taskErr = err
 	} else {
 		mode := statusline.ModesEnum.Normal
 		if m.ctx.DevMode {
@@ -86,9 +99,9 @@ func (m *Model) finishTask(err error, kb help.KeyMap) {
 		}
 		m.setStatus(mode, "")
 		m.setHelpKeys(kb)
-		m.ctx.TaskErr = nil
+		m.taskErr = nil
 	}
-	m.ctx.TaskStatus = context.TaskFinished
+	m.taskStatus = taskFinished
 }
 
 func (m *Model) updateSpinnerViewCommand(msg tea.Msg) tea.Cmd {
@@ -102,22 +115,22 @@ func (m *Model) updateSpinnerViewCommand(msg tea.Msg) tea.Cmd {
 }
 
 func (m *Model) toggleLeftPanel() {
-	m.ctx.IsLeftPanelOpen = !m.ctx.IsLeftPanelOpen
+	m.isLeftOpen = !m.isLeftOpen
 	m.recomputeLayout()
 }
 
 func (m *Model) toggleRightPanel() {
-	m.ctx.IsRightPanelOpen = !m.ctx.IsRightPanelOpen
+	m.isRightOpen = !m.isRightOpen
 	m.recomputeLayout()
 }
 
 func (m *Model) recomputeLayout() {
-	m.layout = computeLayout(m.ctx.Window, m.ctx.IsLeftPanelOpen, m.ctx.IsRightPanelOpen)
+	m.layout = computeLayout(m.ctx.Window, m.isLeftOpen, m.isRightOpen)
 	m.applyLayout()
 }
 
 func (m *Model) setHelpKeys(kb help.KeyMap) {
-	m.ctx.Keybinds = kb
+	m.Statusline.Keybinds = kb
 }
 
 func (m *Model) SelectMR() {

--- a/internal/tui/app/update.go
+++ b/internal/tui/app/update.go
@@ -71,7 +71,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.setHelpKeys(mergerequests.Keybinds)
 
 	case details.RespondCommentMsg:
-		m.ctx.IsModalOpen = true
+		m.isModalOpen = true
 		m.ctx.FocusedPanel = context.Modal
 		m.Modal.Header = "Respond to thread"
 		m.Modal.Content = m.Input.View()
@@ -79,15 +79,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case modal.CloseModalMsg:
 		m.Input.Blur()
-		if m.ctx.TaskErr != nil {
+		if m.taskErr != nil {
 			mode := statusline.ModesEnum.Normal
 			if m.ctx.DevMode {
 				mode = statusline.ModesEnum.Dev
 			}
 			m.setStatus(mode, "")
 		}
-		m.ctx.IsModalOpen = false
-		if m.ctx.IsRightPanelOpen {
+		m.isModalOpen = false
+		if m.isRightOpen {
 			m.Details.SetFocus()
 			m.setHelpKeys(details.Keybinds)
 		} else {
@@ -100,7 +100,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.finishTask(msg.Err, mergerequests.Keybinds)
 		if msg.Err == nil {
 			t := m.getMergeRequestModel(msg)()
-			if m.ctx.IsLeftPanelOpen {
+			if m.isLeftOpen {
 				m.toggleLeftPanel()
 				m.MergeRequests.SetFocus()
 			}
@@ -127,7 +127,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			c := m.Details.GetViewportContent(d, details.MergeRequestDetails(mr))
 			m.Details.Viewport.SetContent(c)
 
-			if !m.ctx.IsRightPanelOpen {
+			if !m.isRightOpen {
 				m.toggleRightPanel()
 				m.Details.SetFocus()
 			}
@@ -171,10 +171,10 @@ func (m *Model) handleGlobalKeys(msg tea.KeyMsg) tea.Cmd {
 
 	switch {
 	case match(gk.MockFetch):
-		if m.ctx.TaskStatus == context.TaskStarted {
-			m.ctx.TaskStatus = context.TaskFinished
-		} else if m.ctx.TaskStatus == context.TaskFinished || m.ctx.TaskStatus == context.TaskIdle {
-			m.ctx.TaskStatus = context.TaskStarted
+		if m.taskStatus == taskStarted {
+			m.taskStatus = taskFinished
+		} else if m.taskStatus == taskFinished || m.taskStatus == taskIdle {
+			m.taskStatus = taskStarted
 		}
 
 	case match(gk.ThrowError):
@@ -185,19 +185,19 @@ func (m *Model) handleGlobalKeys(msg tea.KeyMsg) tea.Cmd {
 		return tea.Quit
 
 	case match(gk.OpenModal):
-		if m.ctx.TaskErr != nil {
-			m.ctx.IsModalOpen = true
+		if m.taskErr != nil {
+			m.isModalOpen = true
 			m.Modal.Header = "Error"
-			m.Modal.Content = m.ctx.TaskErr.Error()
+			m.Modal.Content = m.taskErr.Error()
 			m.Modal.SetFocus()
 		}
 
 	case match(gk.ToggleLeftPanel):
 		m.toggleLeftPanel()
-		if m.ctx.IsRightPanelOpen {
+		if m.isRightOpen {
 			m.toggleRightPanel()
 		}
-		if m.ctx.IsLeftPanelOpen {
+		if m.isLeftOpen {
 			m.Projects.SetFocus()
 			m.setHelpKeys(projects.Keybinds)
 		} else {

--- a/internal/tui/app/view.go
+++ b/internal/tui/app/view.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/charmbracelet/lipgloss"
-	"github.com/felipeospina21/mrglab/internal/context"
 	"github.com/felipeospina21/mrglab/internal/tui/components/modal"
 	"github.com/felipeospina21/mrglab/internal/tui/components/projects"
 	"github.com/felipeospina21/mrglab/internal/tui/components/table"
@@ -14,13 +13,13 @@ import (
 func (m Model) View() string {
 	left := projects.DocStyle.Render(m.Projects.List.View())
 	render := style.MainFrameStyle.Render
-	isInitialScreen := m.ctx.TaskStatus == context.TaskIdle
-	isFetching := m.ctx.TaskStatus == context.TaskStarted
+	isInitialScreen := m.taskStatus == taskIdle
+	isFetching := m.taskStatus == taskStarted
 
 	switch {
 	case isInitialScreen:
-		if m.ctx.TaskErr != nil {
-			body := lipgloss.JoinHorizontal(0, left, m.ctx.TaskErr.Error())
+		if m.taskErr != nil {
+			body := lipgloss.JoinHorizontal(0, left, m.taskErr.Error())
 			sl := m.Statusline.View()
 			return render(lipgloss.JoinVertical(0, body, sl))
 		}
@@ -32,7 +31,7 @@ func (m Model) View() string {
 		sl := m.Statusline.View()
 		return render(lipgloss.JoinVertical(0, body, sl))
 
-	case m.ctx.IsModalOpen:
+	case m.isModalOpen:
 		m.setHelpKeys(modal.Keybinds)
 		body := m.Modal.View()
 		sl := m.Statusline.View()
@@ -41,7 +40,7 @@ func (m Model) View() string {
 	default:
 		body, sl := m.getMainPanelComponents()
 
-		if m.ctx.IsLeftPanelOpen {
+		if m.isLeftOpen {
 			if isFetching {
 				textStyle := lipgloss.NewStyle().Foreground(lipgloss.Color(style.Violet[300])).Render
 				body = fmt.Sprintf("\n %s%s%s\n\n",
@@ -55,7 +54,7 @@ func (m Model) View() string {
 			return render(lipgloss.JoinVertical(0, main, sl))
 		}
 
-		if m.ctx.IsRightPanelOpen {
+		if m.isRightOpen {
 			right := m.Details.View()
 			main := lipgloss.JoinHorizontal(0, body, right)
 			return render(lipgloss.JoinVertical(0, main, sl))

--- a/internal/tui/components/projects/projects.go
+++ b/internal/tui/components/projects/projects.go
@@ -44,8 +44,6 @@ func New(ctx *context.AppContext, client *gitlab.Client, projectList []config.Pr
 	// l.Styles.PaginationStyle = PaginationStyle
 	l.SetShowHelp(false)
 
-	ctx.IsLeftPanelOpen = true
-
 	return Model{
 		List:   l,
 		ctx:    ctx,

--- a/internal/tui/components/statusline/statusline.go
+++ b/internal/tui/components/statusline/statusline.go
@@ -29,21 +29,23 @@ var ModesEnum = Modes{
 }
 
 type Model struct {
-	Status  string
-	Content string
-	Width   int
-	Spinner spinner.Model
-	Help    help.Model
-	ctx     *context.AppContext
+	Status   string
+	Content  string
+	Width    int
+	Spinner  spinner.Model
+	Help     help.Model
+	Keybinds help.KeyMap
+	ctx      *context.AppContext
 }
 
-func New(ctx *context.AppContext) Model {
+func New(ctx *context.AppContext, keybinds help.KeyMap) Model {
 	status := ModesEnum.Normal
 	if ctx.DevMode {
 		status = ModesEnum.Dev
 	}
 	return Model{
-		Status: status,
+		Status:   status,
+		Keybinds: keybinds,
 		Spinner: spinner.New(
 			spinner.WithSpinner(spinner.Dot),
 			spinner.WithStyle(SpinnerStyle),
@@ -82,7 +84,7 @@ func (m Model) View() string {
 
 	help := helpText.
 		Width(width - w(statusKey) - w(statusVal) - w(encoding) - w(projectName)).
-		Render(" " + m.Help.View(m.ctx.Keybinds) + " ")
+		Render(" " + m.Help.View(m.Keybinds) + " ")
 
 	bar := lipgloss.JoinHorizontal(lipgloss.Top,
 		statusKey,


### PR DESCRIPTION
### Step 9 — Trim AppContext

AppContext was a shared mutable bag that every component could read and write. Fields like IsLeftPanelOpen, IsRightPanelOpen, IsModalOpen, Keybinds, TaskStatus, and TaskErr were only used by the app layer, but because they lived on AppContext, any component could reach in and mutate them, making data flow invisible.

- Moved IsLeftPanelOpen, IsRightPanelOpen, IsModalOpen, TaskStatus, TaskErr to app.Model
- Moved Keybinds to statusline.Model (set by app via m.Statusline.Keybinds)
- TaskStatus type and constants are now unexported in app package
- AppContext now only holds genuinely shared state: Window, SelectedProject, SelectedMR, FocusedPanel, PanelHeight, DevMode
- Removed help import from context package

This makes ownership explicit — panel visibility and task state are app-level concerns that belong on app.Model, not on a shared context struct that every component can mutate.