### PR TITLE
add changelog, release command and release gh action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .log
 .kiro
 mrglab
+dist/
+debug.log
+c.out

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,33 @@
+version: 2
+
+builds:
+  - main: .
+    binary: mrglab
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - format: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+
+changelog:
+  use: github
+  filters:
+    exclude:
+      - "^chore"
+      - "^ci"
+
+release:
+  github:
+    owner: felipeospina21
+    name: mrglab

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [0.1.0] - 2026-03-26
+
+Initial public release.
+
+### Features
+
+- Browse open merge requests for configured GitLab projects
+- View MR details: description, pipeline stages, approvals, branches, and discussions
+- Merge a merge request directly from the TUI
+- Open any MR in the default browser
+- Respond to discussion threads (post comments)
+- Navigate between resolvable discussions with `n`/`N`
+- Copy modal content to clipboard
+- Toggle project list and details panels
+- Full-screen help modal with all keybindings
+- Loading spinner when fetching MR list and details
+- Dev mode with mocked data (`mrglab -dev`)
+
+### Documentation
+
+- README with features, keybindings, and configuration reference
+- Godoc comments on all exported types and functions
+- CONTRIBUTING.md with issue-first workflow
+- MIT License
+
+### CI
+
+- Build and vet checks on pull requests
+- Conventional commit validation
+- PR template with checklist

--- a/Makefile
+++ b/Makefile
@@ -13,3 +13,15 @@ test:
 cover: 
 	go test ./... -coverprofile=c.out
 	go tool cover -html="c.out"
+
+release:
+ifndef v
+	$(error Usage: make release v=0.2.0)
+endif
+	@echo "Releasing v$(v)..."
+	git add -A
+	git commit -m "chore release v$(v)" --allow-empty
+	git tag v$(v)
+	git push
+	git push origin v$(v)
+	@echo "Done. v$(v) released."


### PR DESCRIPTION
## Related issue


## What changed

add versioning

## Checklist

- [ ] This PR is linked to an existing GitHub issue
- [ ] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, etc.)
- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Code is formatted with `gofmt`
- [ ] New exported types/functions have godoc comments
- [ ] Tested in dev mode (`go run . -dev`)
