### PR TITLE
add form and create mr functionality

### DIFF
--- a/internal/exec/git.go
+++ b/internal/exec/git.go
@@ -1,0 +1,15 @@
+package exec
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// CurrentGitBranch returns the current git branch name, or empty string on error.
+func CurrentGitBranch() string {
+	out, err := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/internal/gitlab/createmergerequests.go
+++ b/internal/gitlab/createmergerequests.go
@@ -1,0 +1,28 @@
+package gitlab
+
+import (
+	"context"
+	"time"
+)
+
+// CreateMergeRequest creates a new merge request via the GitLab API.
+func (c *Client) CreateMergeRequest(
+	projectID string,
+	input CreateMergeRequestInput,
+) (CreateMergeRequestResponse, error) {
+	if c.devMode {
+		time.Sleep(500 * time.Millisecond)
+		return CreateMergeRequestResponse{}, nil
+	}
+
+	var mutation createMergeRequestMutation
+	input.ProjectPath = c.projectFullPath(projectID)
+	variables := createMergeRequestVariables(input)
+
+	err := c.gql.Mutate(context.Background(), &mutation, variables)
+	if err != nil {
+		return CreateMergeRequestResponse{}, err
+	}
+
+	return mutation.MergeRequestCreate, nil
+}

--- a/internal/gitlab/mergerequests.go
+++ b/internal/gitlab/mergerequests.go
@@ -2,7 +2,12 @@ package gitlab
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
 	"time"
+
+	"github.com/hasura/go-graphql-client"
 )
 
 // GetProjectMergeRequests fetches the open merge requests for a project.
@@ -47,6 +52,243 @@ func (c *Client) GetMergeRequest(
 	}
 
 	return query.Project.MergeRequest, nil
+}
+
+// ProjectInfo holds the default branch and MR description template from project settings.
+type ProjectInfo struct {
+	DefaultBranch         string
+	MergeRequestsTemplate string
+}
+
+// GetProjectInfo fetches the project's default branch and MR description template.
+func (c *Client) GetProjectInfo(projectID string) (ProjectInfo, error) {
+	if c.devMode {
+		time.Sleep(200 * time.Millisecond)
+		return ProjectInfo{DefaultBranch: "main", MergeRequestsTemplate: mrDescriptionTemplatesMock[0].Content}, nil
+	}
+
+	url := fmt.Sprintf("%s/api/v4/projects/%s", c.cfg.BaseURL, projectID)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return ProjectInfo{}, err
+	}
+	req.Header.Set("PRIVATE-TOKEN", c.cfg.APIToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return ProjectInfo{}, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return ProjectInfo{}, fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	var data struct {
+		DefaultBranch         string `json:"default_branch"`
+		MergeRequestsTemplate string `json:"merge_requests_template"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return ProjectInfo{}, err
+	}
+
+	return ProjectInfo{
+		DefaultBranch:         data.DefaultBranch,
+		MergeRequestsTemplate: data.MergeRequestsTemplate,
+	}, nil
+}
+
+// MRDescriptionTemplate represents a resolved MR description template.
+type MRDescriptionTemplate struct {
+	Name    string
+	Content string
+}
+
+// GetMRDescriptionTemplates fetches MR description templates from all available sources
+// in parallel: project-level files, group-level templates (REST), and the project default
+// description setting. Results are merged and deduplicated by name (project files win).
+func (c *Client) GetMRDescriptionTemplates(projectID string) ([]MRDescriptionTemplate, error) {
+	if c.devMode {
+		time.Sleep(300 * time.Millisecond)
+		return mrDescriptionTemplatesMock, nil
+	}
+
+	type fileResult struct {
+		templates []MRDescriptionTemplate
+		err       error
+	}
+	type restResult struct {
+		templates []MRDescriptionTemplate
+		err       error
+	}
+	type defaultResult struct {
+		content string
+		err     error
+	}
+
+	fileCh := make(chan fileResult, 1)
+	restCh := make(chan restResult, 1)
+	defaultCh := make(chan defaultResult, 1)
+
+	fullPath := c.projectFullPath(projectID)
+
+	// Source 1: project-level files via GraphQL
+	go func() {
+		templates, err := c.fetchProjectFileTemplates(fullPath)
+		fileCh <- fileResult{templates, err}
+	}()
+
+	// Source 2: group-level templates via REST
+	go func() {
+		templates, err := c.fetchRESTTemplates(projectID)
+		restCh <- restResult{templates, err}
+	}()
+
+	// Source 3: project default description
+	go func() {
+		info, err := c.GetProjectInfo(projectID)
+		defaultCh <- defaultResult{info.MergeRequestsTemplate, err}
+	}()
+
+	fileRes := <-fileCh
+	restRes := <-restCh
+	defaultRes := <-defaultCh
+
+	// Merge: project files first, then group templates (dedup by name), then default
+	seen := make(map[string]bool)
+	var merged []MRDescriptionTemplate
+
+	for _, t := range fileRes.templates {
+		if !seen[t.Name] {
+			seen[t.Name] = true
+			merged = append(merged, t)
+		}
+	}
+
+	for _, t := range restRes.templates {
+		if !seen[t.Name] {
+			seen[t.Name] = true
+			merged = append(merged, t)
+		}
+	}
+
+	if len(merged) == 0 && defaultRes.content != "" {
+		merged = append(merged, MRDescriptionTemplate{Name: "Default", Content: defaultRes.content})
+	}
+
+	return merged, nil
+}
+
+func (c *Client) fetchProjectFileTemplates(fullPath graphql.ID) ([]MRDescriptionTemplate, error) {
+	var tree getRepositoryTree
+	vars := map[string]any{
+		"fullPath": fullPath,
+		"path":     ".gitlab/merge_request_templates",
+		"ref":      "HEAD",
+	}
+
+	err := c.gql.Query(context.Background(), &tree, vars)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := tree.Project.Repository.Tree.Blobs.Nodes
+	if len(entries) == 0 {
+		return nil, nil
+	}
+
+	var paths []string
+	for _, e := range entries {
+		paths = append(paths, e.Path)
+	}
+
+	var blobs getRepositoryBlobs
+	blobVars := map[string]any{
+		"fullPath": fullPath,
+		"paths":    paths,
+		"ref":      "HEAD",
+	}
+
+	err = c.gql.Query(context.Background(), &blobs, blobVars)
+	if err != nil {
+		return nil, err
+	}
+
+	var templates []MRDescriptionTemplate
+	for _, b := range blobs.Project.Repository.Blobs.Nodes {
+		templates = append(templates, MRDescriptionTemplate{Name: b.Name, Content: b.RawTextBlob})
+	}
+	return templates, nil
+}
+
+func (c *Client) fetchRESTTemplates(projectID string) ([]MRDescriptionTemplate, error) {
+	// List available templates
+	listURL := fmt.Sprintf("%s/api/v4/projects/%s/templates/merge_requests", c.cfg.BaseURL, projectID)
+	req, err := http.NewRequest("GET", listURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("PRIVATE-TOKEN", c.cfg.APIToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, nil
+	}
+
+	var list []struct {
+		Key  string `json:"key"`
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&list); err != nil {
+		return nil, err
+	}
+
+	if len(list) == 0 {
+		return nil, nil
+	}
+
+	// Fetch content for each template
+	var templates []MRDescriptionTemplate
+	for _, item := range list {
+		content, err := c.fetchRESTTemplateContent(projectID, item.Key)
+		if err != nil {
+			continue
+		}
+		templates = append(templates, MRDescriptionTemplate{Name: item.Name, Content: content})
+	}
+	return templates, nil
+}
+
+func (c *Client) fetchRESTTemplateContent(projectID, key string) (string, error) {
+	url := fmt.Sprintf("%s/api/v4/projects/%s/templates/merge_requests/%s", c.cfg.BaseURL, projectID, key)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("PRIVATE-TOKEN", c.cfg.APIToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+
+	var data struct {
+		Content string `json:"content"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return "", err
+	}
+	return data.Content, nil
 }
 
 // AcceptMergeRequest merges a merge request via the GitLab API.

--- a/internal/gitlab/mock.go
+++ b/internal/gitlab/mock.go
@@ -402,6 +402,27 @@ var mergeRequestResponseMock = MergeRequestResponse{
 	},
 }
 
+var mrDescriptionTemplatesMock = []MRDescriptionTemplate{
+	{
+		Name: "Default",
+		Content: `## Summary
+
+Add a quick summary of what this MR is addressing.
+
+### Related Issue
+
+Add a link to an existing issue or bug here.
+
+### Checklist
+
+- [ ] Code follows the project style guidelines
+- [ ] Tests have been added or updated
+- [ ] Documentation has been updated
+- [ ] Changes have been tested locally
+`,
+	},
+}
+
 const MarkdownContentMock = `
 # Today's Menu
 

--- a/internal/gitlab/queries.go
+++ b/internal/gitlab/queries.go
@@ -20,6 +20,34 @@ type getMergeRequest struct {
 	} `graphql:"project(fullPath: $fullPath)"`
 }
 
+type getRepositoryTree struct {
+	Project struct {
+		Repository struct {
+			Tree struct {
+				Blobs struct {
+					Nodes []struct {
+						Name string
+						Path string
+					}
+				}
+			} `graphql:"tree(path: $path, ref: $ref)"`
+		}
+	} `graphql:"project(fullPath: $fullPath)"`
+}
+
+type getRepositoryBlobs struct {
+	Project struct {
+		Repository struct {
+			Blobs struct {
+				Nodes []struct {
+					Name        string
+					RawTextBlob string
+				}
+			} `graphql:"blobs(paths: $paths, ref: $ref)"`
+		}
+	} `graphql:"project(fullPath: $fullPath)"`
+}
+
 // Mutation structs
 
 type acceptMergeRequestMutation struct {
@@ -102,5 +130,34 @@ func createNoteVariables(input CreateNoteInput) map[string]any {
 		"noteableId":   input.NoteableId,
 		"discussionId": input.DiscussionId,
 		"body":         input.Body,
+	}
+}
+
+// Mutation struct for creating a merge request.
+type createMergeRequestMutation struct {
+	MergeRequestCreate CreateMergeRequestResponse `graphql:"mergeRequestCreate(input:{projectPath:$projectPath,sourceBranch:$sourceBranch,targetBranch:$targetBranch,title:$title,description:$description})"`
+}
+
+// CreateMergeRequestInput holds the input for the create merge request mutation.
+type CreateMergeRequestInput struct {
+	ProjectPath  graphql.ID
+	SourceBranch string
+	TargetBranch string
+	Title        string
+	Description  string
+}
+
+// CreateMergeRequestResponse is the result of a create merge request mutation.
+type CreateMergeRequestResponse struct {
+	Errors []string
+}
+
+func createMergeRequestVariables(input CreateMergeRequestInput) map[string]any {
+	return map[string]any{
+		"projectPath":  input.ProjectPath,
+		"sourceBranch": input.SourceBranch,
+		"targetBranch": input.TargetBranch,
+		"title":        input.Title,
+		"description":  input.Description,
 	}
 }

--- a/internal/tui/app/commands.go
+++ b/internal/tui/app/commands.go
@@ -1,8 +1,12 @@
 package app
 
 import (
+	"fmt"
+	"strings"
+
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/felipeospina21/mrglab/internal/exec"
+	"github.com/felipeospina21/mrglab/internal/gitlab"
 	"github.com/felipeospina21/mrglab/internal/tui"
 	"github.com/felipeospina21/mrglab/internal/tui/components/details"
 	"github.com/felipeospina21/mrglab/internal/tui/components/mergerequests"
@@ -55,4 +59,48 @@ func (m *Model) openInBrowser() {
 	colIdx := mergerequests.GetColIndex(mergerequests.ColNames.URL)
 	url := m.MergeRequests.Table.SelectedRow()[colIdx]
 	exec.Openbrowser(url)
+}
+
+func (m Model) createMergeRequest() tea.Cmd {
+	source := strings.TrimSpace(m.createForm.source.Value())
+	target := strings.TrimSpace(m.createForm.target.Value())
+	title := strings.TrimSpace(m.createForm.title.Value())
+	description := strings.TrimSpace(m.createForm.description.Value())
+
+	if target == "" {
+		target = "main"
+	}
+
+	if source == "" || title == "" {
+		return func() tea.Msg {
+			return tui.MRCreatedMsg{
+				Err: fmt.Errorf("source branch and title are required"),
+			}
+		}
+	}
+	return m.MergeRequests.CreateMergeRequest(gitlab.CreateMergeRequestInput{
+		SourceBranch: source,
+		TargetBranch: target,
+		Title:        title,
+		Description:  description,
+	})
+}
+
+// parseBranches parses "source→target" or "source->target" format.
+// If no target is given, defaults to "main".
+func parseBranches(input string) (source, target string) {
+	sep := "→"
+	if !strings.Contains(input, sep) {
+		sep = "->"
+	}
+
+	parts := strings.SplitN(input, sep, 2)
+	source = strings.TrimSpace(parts[0])
+	if len(parts) > 1 {
+		target = strings.TrimSpace(parts[1])
+	}
+	if target == "" {
+		target = "main"
+	}
+	return source, target
 }

--- a/internal/tui/app/form.go
+++ b/internal/tui/app/form.go
@@ -1,0 +1,180 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/charmbracelet/bubbles/textarea"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/felipeospina21/mrglab/internal/tui/components/modal"
+	"github.com/felipeospina21/mrglab/internal/tui/icon"
+	"github.com/felipeospina21/mrglab/internal/tui/style"
+)
+
+const (
+	formFieldSource = iota
+	formFieldTarget
+	formFieldTitle
+	formFieldDescription
+	formFieldCount
+)
+
+type createMRForm struct {
+	source      textinput.Model
+	target      textinput.Model
+	title       textinput.Model
+	description textarea.Model
+	focused     int
+	width       int
+}
+
+var (
+	labelStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(style.Violet[400])).
+			Bold(true).
+			MarginTop(1)
+
+	arrowStyle = lipgloss.NewStyle().
+			Foreground(lipgloss.Color(style.MediumGray)).
+			Bold(true).
+			Padding(0, 0, 0, 4)
+)
+
+func newCreateMRForm() createMRForm {
+	source := textinput.New()
+	source.Placeholder = "source branch"
+	source.CharLimit = 200
+
+	target := textinput.New()
+	target.Placeholder = "target branch"
+	target.CharLimit = 200
+
+	title := textinput.New()
+	title.Placeholder = "feat: add new feature"
+	title.CharLimit = 200
+
+	desc := textarea.New()
+	desc.Placeholder = "Description (populated from template if available)"
+	desc.CharLimit = 0
+	desc.ShowLineNumbers = false
+
+	return createMRForm{
+		source:      source,
+		target:      target,
+		title:       title,
+		description: desc,
+	}
+}
+
+func (f *createMRForm) Focus() tea.Cmd {
+	f.focused = formFieldSource
+	return f.source.Focus()
+}
+
+func (f *createMRForm) Blur() {
+	f.source.Blur()
+	f.target.Blur()
+	f.title.Blur()
+	f.description.Blur()
+	f.focused = formFieldSource
+}
+
+func (f *createMRForm) Reset() {
+	f.source.Reset()
+	f.target.Reset()
+	f.title.Reset()
+	f.description.Reset()
+	f.focused = formFieldSource
+}
+
+func (f *createMRForm) SetSize(w, h int) {
+	f.width = w
+	f.source.Width = w
+	f.target.Width = w
+	f.title.Width = w
+
+	// labels(3 * 2) + source(1) + arrow(1+1 padding) + target(1) + title(1) + desc label(2)
+	overhead := 13
+	descH := h - overhead
+	if descH < 3 {
+		descH = 3
+	}
+	f.description.SetWidth(w)
+	f.description.SetHeight(descH)
+}
+
+func (f *createMRForm) NextField() tea.Cmd {
+	f.blurCurrent()
+	f.focused = (f.focused + 1) % formFieldCount
+	return f.focusCurrent()
+}
+
+func (f *createMRForm) PrevField() tea.Cmd {
+	f.blurCurrent()
+	f.focused = (f.focused - 1 + formFieldCount) % formFieldCount
+	return f.focusCurrent()
+}
+
+func (f *createMRForm) blurCurrent() {
+	switch f.focused {
+	case formFieldSource:
+		f.source.Blur()
+	case formFieldTarget:
+		f.target.Blur()
+	case formFieldTitle:
+		f.title.Blur()
+	case formFieldDescription:
+		f.description.Blur()
+	}
+}
+
+func (f *createMRForm) focusCurrent() tea.Cmd {
+	switch f.focused {
+	case formFieldSource:
+		return f.source.Focus()
+	case formFieldTarget:
+		return f.target.Focus()
+	case formFieldTitle:
+		return f.title.Focus()
+	case formFieldDescription:
+		return f.description.Focus()
+	}
+	return nil
+}
+
+func (f *createMRForm) Update(msg tea.Msg) tea.Cmd {
+	var cmd tea.Cmd
+	switch f.focused {
+	case formFieldSource:
+		f.source, cmd = f.source.Update(msg)
+	case formFieldTarget:
+		f.target, cmd = f.target.Update(msg)
+	case formFieldTitle:
+		f.title, cmd = f.title.Update(msg)
+	case formFieldDescription:
+		f.description, cmd = f.description.Update(msg)
+	}
+	return cmd
+}
+
+func (f *createMRForm) View() string {
+	return lipgloss.JoinVertical(0,
+		labelStyle.Render("Branches"),
+		f.source.View(),
+		arrowStyle.Render(fmt.Sprintf("  %s", icon.ArrowDown)),
+		f.target.View(),
+		labelStyle.Render("Title"),
+		f.title.View(),
+		labelStyle.Render("Description"),
+		f.description.View(),
+	)
+}
+
+func modalContentWidth(windowW int) int {
+	return modal.ContentWidth(windowW)
+}
+
+func modalContentHeight(windowH int) int {
+	return modal.ContentHeight(windowH)
+}

--- a/internal/tui/app/model.go
+++ b/internal/tui/app/model.go
@@ -44,6 +44,9 @@ type Model struct {
 		DiscussionId string
 		NoteableId   string
 	}
+	pendingCreateMR bool
+	formReady       bool
+	createForm      createMRForm
 }
 
 // InitMainModel creates and returns the initial application model.
@@ -69,6 +72,7 @@ func InitMainModel(ctx *context.AppContext, cfg *config.Config, client *gitlab.C
 		ctx:        ctx,
 		taskStatus: taskIdle,
 		isLeftOpen: true,
+		createForm: newCreateMRForm(),
 	}
 }
 

--- a/internal/tui/app/update.go
+++ b/internal/tui/app/update.go
@@ -14,6 +14,7 @@ import (
 	"github.com/felipeospina21/mrglab/internal/logger"
 	"github.com/felipeospina21/mrglab/internal/tui"
 	"github.com/felipeospina21/mrglab/internal/tui/components/details"
+	"github.com/felipeospina21/mrglab/internal/tui/components/loader"
 	"github.com/felipeospina21/mrglab/internal/tui/components/mergerequests"
 	"github.com/felipeospina21/mrglab/internal/tui/components/modal"
 	"github.com/felipeospina21/mrglab/internal/tui/components/projects"
@@ -76,6 +77,33 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case mergerequests.OpenInBrowserMsg, details.OpenInBrowserMsg:
 		m.openInBrowser()
 
+	case mergerequests.CreateMRMsg:
+		m.isModalOpen = true
+		m.pendingCreateMR = true
+		m.ctx.FocusedPanel = context.Modal
+		m.Modal.Header = "New Merge Request"
+		m.Modal.Content = loader.View(m.Spinner.View())
+		cmds = append(cmds, m.MergeRequests.FetchMRTemplates())
+
+	case tui.MRTemplatesFetchedMsg:
+		if m.pendingCreateMR {
+			m.createForm.SetSize(modalContentWidth(m.ctx.Window.Width), modalContentHeight(m.ctx.Window.Height))
+			if msg.Err == nil {
+				if msg.SourceBranch != "" {
+					m.createForm.source.SetValue(msg.SourceBranch)
+				}
+				if msg.DefaultBranch != "" {
+					m.createForm.target.SetValue(msg.DefaultBranch)
+				}
+				if len(msg.Templates) > 0 {
+					m.createForm.description.SetValue(msg.Templates[0].Content)
+				}
+			}
+			m.formReady = true
+			m.Modal.Content = m.createForm.View()
+			cmds = append(cmds, m.createForm.Focus())
+		}
+
 	case details.ClosePanelMsg:
 		m.toggleRightPanel()
 		m.MergeRequests.SetFocus()
@@ -93,7 +121,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case modal.CloseModalMsg:
 		m.Input.Blur()
 		m.Input.Reset()
+		m.createForm.Blur()
+		m.createForm.Reset()
 		m.Modal.IsError = false
+		m.pendingCreateMR = false
+		m.formReady = false
 		if m.taskErr != nil {
 			mode := statusline.ModesEnum.Normal
 			if m.ctx.DevMode {
@@ -131,8 +163,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				})
 			}))
 		}
+		if m.pendingCreateMR {
+			cmds = append(cmds, m.startTask(func() tea.Cmd {
+				return m.createMergeRequest()
+			}))
+			m.pendingCreateMR = false
+		}
 		m.Input.Blur()
 		m.Input.Reset()
+		m.createForm.Blur()
+		m.createForm.Reset()
+		m.formReady = false
 		m.isModalOpen = false
 		if m.isRightOpen {
 			m.Details.SetFocus()
@@ -203,11 +244,26 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 
+	case tui.MRCreatedMsg:
+		m.finishTask(msg.Err, mergerequests.Keybinds)
+		if msg.Err == nil {
+			if len(msg.Errors) > 0 {
+				e := strings.Join(msg.Errors, ", ")
+				cmds = append(cmds, func() tea.Msg { return errors.New(e) })
+			} else {
+				m.Statusline.Content = "✓ MR created"
+				cmds = append(cmds, m.startTask(m.fetchMergeRequestsList))
+			}
+		}
+
 	case spinner.TickMsg:
 		var spin tea.Cmd
 		cmd = m.updateSpinnerViewCommand(msg)
 		m.Spinner, spin = m.Spinner.Update(msg)
 		m.Details.SpinnerView = m.Spinner.View()
+		if m.pendingCreateMR && m.isModalOpen && !m.formReady {
+			m.Modal.Content = loader.View(m.Spinner.View())
+		}
 		cmds = append(cmds, cmd, spin)
 
 	case tea.WindowSizeMsg:
@@ -219,6 +275,24 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.Input, cmd = m.Input.Update(msg)
 		m.Modal.Content = m.Input.View()
 		cmds = append(cmds, cmd)
+	}
+
+	if m.pendingCreateMR && m.isModalOpen && m.formReady {
+		if keyMsg, ok := msg.(tea.KeyMsg); ok {
+			switch keyMsg.String() {
+			case "tab":
+				cmds = append(cmds, m.createForm.NextField())
+			case "shift+tab":
+				cmds = append(cmds, m.createForm.PrevField())
+			default:
+				cmd = m.createForm.Update(msg)
+				cmds = append(cmds, cmd)
+			}
+		} else {
+			cmd = m.createForm.Update(msg)
+			cmds = append(cmds, cmd)
+		}
+		m.Modal.Content = m.createForm.View()
 	}
 
 	return m, tea.Batch(cmds...)

--- a/internal/tui/components/details/render.go
+++ b/internal/tui/components/details/render.go
@@ -86,7 +86,7 @@ func renderBranches(source, target string) string {
 	var content strings.Builder
 	content.WriteString(icon.Rebase)
 	content.WriteString(target)
-	content.WriteString(" <- ")
+	content.WriteString(fmt.Sprintf(" %s ", icon.ArrowLeft))
 	content.WriteString(source)
 
 	return s.Render(content.String())

--- a/internal/tui/components/mergerequests/commands.go
+++ b/internal/tui/components/mergerequests/commands.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
+	execPkg "github.com/felipeospina21/mrglab/internal/exec"
 	"github.com/felipeospina21/mrglab/internal/gitlab"
 	"github.com/felipeospina21/mrglab/internal/tui"
 )
@@ -67,6 +68,61 @@ func (m *Model) CreateNote(input gitlab.CreateNoteInput) tea.Cmd {
 		return tui.NoteCreatedMsg{
 			Errors: res.Errors,
 			Err:    err,
+		}
+	}
+}
+
+// CreateMergeRequest returns a command that creates a new merge request.
+func (m *Model) CreateMergeRequest(input gitlab.CreateMergeRequestInput) tea.Cmd {
+	return func() tea.Msg {
+		res, err := m.client.CreateMergeRequest(m.ctx.SelectedProject.ID, input)
+		return tui.MRCreatedMsg{
+			Errors: res.Errors,
+			Err:    err,
+		}
+	}
+}
+
+// FetchMRTemplates returns a command that fetches MR description templates and branch info.
+func (m *Model) FetchMRTemplates() tea.Cmd {
+	return func() tea.Msg {
+		type tmplResult struct {
+			templates []gitlab.MRDescriptionTemplate
+			err       error
+		}
+		type infoResult struct {
+			info gitlab.ProjectInfo
+			err  error
+		}
+
+		tmplCh := make(chan tmplResult, 1)
+		infoCh := make(chan infoResult, 1)
+
+		go func() {
+			t, err := m.client.GetMRDescriptionTemplates(m.ctx.SelectedProject.ID)
+			tmplCh <- tmplResult{t, err}
+		}()
+
+		go func() {
+			i, err := m.client.GetProjectInfo(m.ctx.SelectedProject.ID)
+			infoCh <- infoResult{i, err}
+		}()
+
+		tr := <-tmplCh
+		ir := <-infoCh
+
+		sourceBranch := execPkg.CurrentGitBranch()
+
+		defaultBranch := "main"
+		if ir.err == nil && ir.info.DefaultBranch != "" {
+			defaultBranch = ir.info.DefaultBranch
+		}
+
+		return tui.MRTemplatesFetchedMsg{
+			Templates:     tr.templates,
+			DefaultBranch: defaultBranch,
+			SourceBranch:  sourceBranch,
+			Err:           tr.err,
 		}
 	}
 }

--- a/internal/tui/components/mergerequests/keys.go
+++ b/internal/tui/components/mergerequests/keys.go
@@ -11,12 +11,13 @@ type MergeReqsKeyMap struct {
 	OpenInBrowser key.Binding
 	Details       key.Binding
 	Merge         key.Binding
+	CreateMR      key.Binding
 	tui.GlobalKeyMap
 }
 
 func (k MergeReqsKeyMap) ShortHelp() []key.Binding {
 	return slices.Concat(
-		[]key.Binding{k.Details, k.OpenInBrowser, k.Merge},
+		[]key.Binding{k.Details, k.OpenInBrowser, k.Merge, k.CreateMR},
 		tui.CommonKeys,
 	)
 }
@@ -24,7 +25,7 @@ func (k MergeReqsKeyMap) ShortHelp() []key.Binding {
 func (k MergeReqsKeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		tui.CommonKeys,
-		{k.Details, k.OpenInBrowser, k.Merge},
+		{k.Details, k.OpenInBrowser, k.Merge, k.CreateMR},
 	}
 }
 
@@ -40,6 +41,10 @@ var Keybinds = MergeReqsKeyMap{
 	Merge: key.NewBinding(
 		key.WithKeys("M"),
 		key.WithHelp("M", "merge MR"),
+	),
+	CreateMR: key.NewBinding(
+		key.WithKeys("N"),
+		key.WithHelp("N", "new MR"),
 	),
 	GlobalKeyMap: tui.GlobalKeys(false),
 }

--- a/internal/tui/components/mergerequests/update.go
+++ b/internal/tui/components/mergerequests/update.go
@@ -10,6 +10,7 @@ type (
 	ViewDetailsMsg    struct{}
 	MergeMRMsg        struct{}
 	OpenInBrowserMsg  struct{}
+	CreateMRMsg       struct{}
 )
 
 func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
@@ -24,6 +25,8 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 			return m, func() tea.Msg { return MergeMRMsg{} }
 		case match(Keybinds.OpenInBrowser):
 			return m, func() tea.Msg { return OpenInBrowserMsg{} }
+		case match(Keybinds.CreateMR):
+			return m, func() tea.Msg { return CreateMRMsg{} }
 		}
 	}
 	m.Table, cmd = m.Table.Update(msg)

--- a/internal/tui/components/modal/modal.go
+++ b/internal/tui/components/modal/modal.go
@@ -92,6 +92,19 @@ func modalSize(available int) int {
 	}
 }
 
+// ContentWidth returns the usable content width inside the modal for a given window width.
+func ContentWidth(windowW int) int {
+	return modalSize(windowW) - boxStyle.GetHorizontalFrameSize()
+}
+
+// ContentHeight returns the usable content height inside the modal for a given window height.
+func ContentHeight(windowH int) int {
+	modalH := modalSize(windowH)
+	header := headerStyle.Render("X")
+	footer := helpStyle.Render("X")
+	return max(modalH-lipgloss.Height(header)-lipgloss.Height(footer)-boxStyle.GetVerticalFrameSize(), 1)
+}
+
 // dimContent strips existing colors and applies a dim foreground.
 func dimContent(s string, w, h int) string {
 	// Ensure background fills the full screen

--- a/internal/tui/icon/icon.go
+++ b/internal/tui/icon/icon.go
@@ -7,6 +7,9 @@ package icon
 const (
 	Alert      = " "
 	Approval   = "󰄴 "
+	ArrowRight = "->"
+	ArrowLeft  = "<-"
+	ArrowDown  = ""
 	Dash       = " "
 	Diff       = " "
 	Discussion = " "

--- a/internal/tui/msg.go
+++ b/internal/tui/msg.go
@@ -40,3 +40,17 @@ type NoteCreatedMsg struct {
 	Errors []string
 	Err    error
 }
+
+// MRCreatedMsg is sent after a merge request has been created.
+type MRCreatedMsg struct {
+	Errors []string
+	Err    error
+}
+
+// MRTemplatesFetchedMsg is sent when MR description templates have been fetched.
+type MRTemplatesFetchedMsg struct {
+	Templates     []gitlab.MRDescriptionTemplate
+	DefaultBranch string
+	SourceBranch  string
+	Err           error
+}


### PR DESCRIPTION

## Create MR from TUI

Added the ability to create merge requests directly from the TUI with a structured form and smart defaults.

### Form fields
- **Source branch** → Target branch: displayed vertically with a ↓ arrow separator
- **Title**: single-line input
- **Description**: multi-line textarea that takes remaining modal height

### Smart pre-population
- **Source branch**: auto-filled from the current local git branch (git rev-parse --abbrev-ref HEAD)
- **Target branch**: fetched from the project's default_branch via the GitLab API
- **Description**: pre-filled from the project's MR description template, resolved from 3 sources in parallel:
  1. Project file templates (.gitlab/merge_request_templates/)
  2. Group-level REST templates
  3. Project default description (merge_requests_template setting)

### UX
- Loading spinner shown while fetching branch/template data
- Tab / Shift+Tab to navigate between fields
- ctrl+s to submit, esc to cancel
- Graceful fallback: if not in a git repo, source branch is left empty for manual input; target defaults to main if API call fails


