### PR TITLE
feat: add confirmation popover before mutation actions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.2
 	charm.land/log/v2 v2.0.0
 	github.com/charmbracelet/x/ansi v0.11.6
-	github.com/felipeospina21/tuishell v0.4.0
+	github.com/felipeospina21/tuishell v0.5.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/hasura/go-graphql-client v0.15.1
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/felipeospina21/tuishell v0.4.0 h1:thl2CYw6wdN/PnbRYZFfTew+dTpIFBGemNfYYT203PE=
-github.com/felipeospina21/tuishell v0.4.0/go.mod h1:PdkAVJRM2ug1qKEuW+myzWJy0Q5sILUlU+gMN6sU/h0=
+github.com/felipeospina21/tuishell v0.5.0 h1:1PyRHMUPfOb6NFBp2CrCYBoPuGJSnI+oy9NyW1ztWoo=
+github.com/felipeospina21/tuishell v0.5.0/go.mod h1:PdkAVJRM2ug1qKEuW+myzWJy0Q5sILUlU+gMN6sU/h0=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=

--- a/internal/tui/app/model.go
+++ b/internal/tui/app/model.go
@@ -37,6 +37,8 @@ type Model struct {
 	pendingCreateMR    bool
 	pendingConfirm     bool
 	statusFilter       popover.ListModel
+	confirmPopover     popover.ConfirmModel
+	pendingAction      tea.Msg
 	formReady          bool
 	createForm      createMRForm
 	ActiveTab       int
@@ -128,7 +130,8 @@ func InitMainModel(ctx *context.AppContext, cfg *config.Config, client *gitlab.C
 		Input:         ti,
 		ctx:           ctx,
 		createForm:    newCreateMRForm(),
-		statusFilter:  popover.NewList(tsstyle.Theme(theme)),
+		statusFilter:   popover.NewList(tsstyle.Theme(theme)),
+		confirmPopover: popover.NewConfirm(tsstyle.Theme(theme)),
 		TabNames:      tabNames,
 	}
 }

--- a/internal/tui/app/update.go
+++ b/internal/tui/app/update.go
@@ -34,6 +34,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 	}
 
+	// Route keys to confirm popover when open
+	if m.confirmPopover.IsOpen() {
+		if _, ok := msg.(tea.KeyPressMsg); ok {
+			var cmd tea.Cmd
+			m.confirmPopover, cmd = m.confirmPopover.Update(msg)
+			return m, cmd
+		}
+	}
+
 	switch msg := msg.(type) {
 
 	case error:
@@ -64,9 +73,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		})
 
 	case mergerequests.MergeMRMsg, details.MergeMRMsg:
-		cmds = append(cmds, func() tea.Msg {
-			return tuishell.StartTaskMsg{Cmd: m.acceptMergeRequest()}
-		})
+		m.pendingAction = msg
+		m.confirmPopover.Open("Merge MR", "Merge this merge request?", "Merge", "Cancel")
 
 	case mergerequests.OpenInBrowserMsg:
 		m.openInBrowser()
@@ -171,6 +179,52 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tuishell.CloseListPopoverMsg:
 		m.statusFilter.Close()
+
+	case tuishell.ConfirmPopoverYesMsg:
+		m.confirmPopover.Close()
+		switch pa := m.pendingAction.(type) {
+		case mergerequests.MergeMRMsg, details.MergeMRMsg:
+			cmds = append(cmds, func() tea.Msg {
+				return tuishell.StartTaskMsg{Cmd: m.acceptMergeRequest()}
+			})
+		case pipelines.RetryPipelineMsg:
+			iidIdx := pipelines.GetColIndex(pipelines.ColNames.IID)
+			iid := m.Pipelines.Table.SelectedRow()[iidIdx]
+			node := m.findPipelineByIID(iid)
+			if node != nil {
+				cmds = append(cmds, func() tea.Msg {
+					return tuishell.StartTaskMsg{Cmd: m.Pipelines.RetryPipeline(node.ID)}
+				})
+			}
+		case pipelines.CancelPipelineMsg:
+			iidIdx := pipelines.GetColIndex(pipelines.ColNames.IID)
+			iid := m.Pipelines.Table.SelectedRow()[iidIdx]
+			node := m.findPipelineByIID(iid)
+			if node != nil {
+				cmds = append(cmds, func() tea.Msg {
+					return tuishell.StartTaskMsg{Cmd: m.Pipelines.CancelPipeline(node.ID)}
+				})
+			}
+		case details.CancelJobMsg:
+			cmds = append(cmds, func() tea.Msg {
+				return tuishell.StartTaskMsg{Cmd: m.Pipelines.CancelJob(pa.JobID)}
+			})
+		case details.PlayJobMsg:
+			if strings.ToLower(pa.Status) == "manual" {
+				cmds = append(cmds, func() tea.Msg {
+					return tuishell.StartTaskMsg{Cmd: m.Pipelines.PlayJob(pa.JobID)}
+				})
+			} else {
+				cmds = append(cmds, func() tea.Msg {
+					return tuishell.StartTaskMsg{Cmd: m.Pipelines.RetryJob(pa.JobID)}
+				})
+			}
+		}
+		m.pendingAction = nil
+
+	case tuishell.ConfirmPopoverNoMsg:
+		m.confirmPopover.Close()
+		m.pendingAction = nil
 
 	case tuishell.CloseModalMsg:
 		m.Input.Blur()
@@ -315,24 +369,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.statusFilter.Open("Filter by Status", pipelineStatusItems())
 
 	case pipelines.RetryPipelineMsg:
-		iidIdx := pipelines.GetColIndex(pipelines.ColNames.IID)
-		iid := m.Pipelines.Table.SelectedRow()[iidIdx]
-		node := m.findPipelineByIID(iid)
-		if node != nil {
-			cmds = append(cmds, func() tea.Msg {
-				return tuishell.StartTaskMsg{Cmd: m.Pipelines.RetryPipeline(node.ID)}
-			})
-		}
+		m.pendingAction = msg
+		m.confirmPopover.Open("Retry Pipeline", "Retry all failed jobs in this pipeline?", "Retry", "Cancel")
 
 	case pipelines.CancelPipelineMsg:
-		iidIdx := pipelines.GetColIndex(pipelines.ColNames.IID)
-		iid := m.Pipelines.Table.SelectedRow()[iidIdx]
-		node := m.findPipelineByIID(iid)
-		if node != nil {
-			cmds = append(cmds, func() tea.Msg {
-				return tuishell.StartTaskMsg{Cmd: m.Pipelines.CancelPipeline(node.ID)}
-			})
-		}
+		m.pendingAction = msg
+		m.confirmPopover.Open("Cancel Pipeline", "Cancel this pipeline?", "Cancel Pipeline", "Go Back")
 
 	case tui.PipelineRetryMsg:
 		cmds = append(cmds, finishTaskCmd(msg.Err, pipelines.Keybinds))
@@ -363,20 +405,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case details.CancelJobMsg:
-		cmds = append(cmds, func() tea.Msg {
-			return tuishell.StartTaskMsg{Cmd: m.Pipelines.CancelJob(msg.JobID)}
-		})
+		m.pendingAction = msg
+		m.confirmPopover.Open("Cancel Job", "Cancel this job?", "Cancel Job", "Go Back")
 
 	case details.PlayJobMsg:
-		if strings.ToLower(msg.Status) == "manual" {
-			cmds = append(cmds, func() tea.Msg {
-				return tuishell.StartTaskMsg{Cmd: m.Pipelines.PlayJob(msg.JobID)}
-			})
-		} else {
-			cmds = append(cmds, func() tea.Msg {
-				return tuishell.StartTaskMsg{Cmd: m.Pipelines.RetryJob(msg.JobID)}
-			})
-		}
+		m.pendingAction = msg
+		m.confirmPopover.Open("Run Job", "Run this job?", "Run", "Cancel")
 
 	case tui.JobPlayMsg:
 		cmds = append(cmds, finishTaskCmd(msg.Err, details.PipelineKeybinds))

--- a/internal/tui/app/view.go
+++ b/internal/tui/app/view.go
@@ -12,5 +12,11 @@ func (m Model) View() tea.View {
 		screen := m.statusFilter.View(v.Content, w, h)
 		return tea.View{Content: screen, AltScreen: v.AltScreen}
 	}
+	if m.confirmPopover.IsOpen() {
+		w := m.ctx.Window.Width
+		h := m.ctx.Window.Height
+		screen := m.confirmPopover.View(v.Content, w, h)
+		return tea.View{Content: screen, AltScreen: v.AltScreen}
+	}
 	return v
 }


### PR DESCRIPTION
## Summary

All mutation actions now show a confirmation popover before executing.

## Changes

- **Merge MR** — "Merge this merge request?"
- **Retry Pipeline** — "Retry all failed jobs in this pipeline?"
- **Cancel Pipeline** — "Cancel this pipeline?"
- **Run/Retry Job** — "Run this job?"
- **Cancel Job** — "Cancel this job?"

Uses the new `popover.ConfirmModel` from tuishell. Pending action is stored as `tea.Msg` and dispatched on confirm via type switch.

## What was tested

- Build passes