### PR TITLE
fix: handle fullscreen toggle in details panel

### DIFF
--- a/internal/tui/components/details/keys.go
+++ b/internal/tui/components/details/keys.go
@@ -13,12 +13,13 @@ type DetailsKeyMap struct {
 	NextDiscussion key.Binding
 	PrevDiscussion key.Binding
 	OpenInBrowser  key.Binding
+	Fullscreen     key.Binding
 	tui.GlobalKeyMap
 }
 
 func (k DetailsKeyMap) ShortHelp() []key.Binding {
 	return slices.Concat(
-		[]key.Binding{k.OpenInBrowser, k.Merge, k.RespondComment, k.NextDiscussion, k.PrevDiscussion},
+		[]key.Binding{k.OpenInBrowser, k.Merge, k.RespondComment, k.NextDiscussion, k.PrevDiscussion, k.Fullscreen},
 		tui.CommonKeys,
 	)
 }
@@ -26,7 +27,7 @@ func (k DetailsKeyMap) ShortHelp() []key.Binding {
 func (k DetailsKeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		tui.CommonKeys,
-		{k.OpenInBrowser, k.Merge, k.RespondComment, k.NextDiscussion, k.PrevDiscussion},
+		{k.OpenInBrowser, k.Merge, k.RespondComment, k.NextDiscussion, k.PrevDiscussion, k.Fullscreen},
 	}
 }
 
@@ -36,12 +37,13 @@ type PipelineDetailsKeyMap struct {
 	PrevJob       key.Binding
 	PlayJob       key.Binding
 	CancelJob     key.Binding
+	Fullscreen    key.Binding
 	tui.GlobalKeyMap
 }
 
 func (k PipelineDetailsKeyMap) ShortHelp() []key.Binding {
 	return slices.Concat(
-		[]key.Binding{k.OpenInBrowser, k.NextJob, k.PrevJob, k.PlayJob, k.CancelJob},
+		[]key.Binding{k.OpenInBrowser, k.NextJob, k.PrevJob, k.PlayJob, k.CancelJob, k.Fullscreen},
 		tui.CommonKeys,
 	)
 }
@@ -49,7 +51,7 @@ func (k PipelineDetailsKeyMap) ShortHelp() []key.Binding {
 func (k PipelineDetailsKeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		tui.CommonKeys,
-		{k.OpenInBrowser, k.NextJob, k.PrevJob, k.PlayJob, k.CancelJob},
+		{k.OpenInBrowser, k.NextJob, k.PrevJob, k.PlayJob, k.CancelJob, k.Fullscreen},
 	}
 }
 
@@ -74,6 +76,10 @@ var PipelineKeybinds = PipelineDetailsKeyMap{
 		key.WithKeys("X"),
 		key.WithHelp("X", "cancel job"),
 	),
+	Fullscreen: key.NewBinding(
+		key.WithKeys("f"),
+		key.WithHelp("f", "fullscreen"),
+	),
 	GlobalKeyMap: tui.GlobalKeys(false),
 }
 
@@ -97,6 +103,10 @@ var Keybinds = DetailsKeyMap{
 	OpenInBrowser: key.NewBinding(
 		key.WithKeys("x"),
 		key.WithHelp("x", "open in browser"),
+	),
+	Fullscreen: key.NewBinding(
+		key.WithKeys("f"),
+		key.WithHelp("f", "fullscreen"),
 	),
 	GlobalKeyMap: tui.GlobalKeys(false),
 }

--- a/internal/tui/components/details/update.go
+++ b/internal/tui/components/details/update.go
@@ -4,6 +4,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/felipeospina21/mrglab/internal/gitlab"
 	"github.com/felipeospina21/mrglab/internal/tui"
+	"github.com/felipeospina21/tuishell"
 )
 
 type (
@@ -36,6 +37,8 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		switch {
 		case match(Keybinds.OpenInBrowser):
 			return m, func() tea.Msg { return OpenInBrowserMsg{} }
+		case match(Keybinds.Fullscreen):
+			return m, func() tea.Msg { return tuishell.ToggleFullscreenMsg{} }
 		case m.PipelineNode != nil && match(PipelineKeybinds.NextJob):
 			m.nextJob()
 		case m.PipelineNode != nil && match(PipelineKeybinds.PrevJob):


### PR DESCRIPTION
## Changes

- Added `Fullscreen` keybinding (`f`) to `DetailsKeyMap` and `PipelineDetailsKeyMap`
- Details component now handles `f` and emits `tuishell.ToggleFullscreenMsg{}`
- Keybinding appears in statusline help when right panel is focused

## Why

Fullscreen toggle was removed from tuishell's global keys (felipeospina21/tuishell#16). Each consumer's right panel now owns the `f` keybinding.

Depends on felipeospina21/tuishell#16