### PR TITLE
Rename dev mode to demo mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 start:
 	go run .
 
-dev:
-	go run . -dev
+demo:
+	go run . -demo
 
 build:
 	go build .

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.2
 	charm.land/log/v2 v2.0.0
 	github.com/charmbracelet/x/ansi v0.11.6
-	github.com/felipeospina21/tuishell v0.8.0
+	github.com/felipeospina21/tuishell v0.9.0
 	github.com/fsnotify/fsnotify v1.9.0
 	github.com/hasura/go-graphql-client v0.15.1
 	github.com/mitchellh/mapstructure v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dlclark/regexp2 v1.11.5 h1:Q/sSnsKerHeCkc/jSTNq1oCm7KiVgUMZRDUoRu0JQZQ=
 github.com/dlclark/regexp2 v1.11.5/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/felipeospina21/tuishell v0.8.0 h1:DKL1pkkVgun5L44h9CIoofG0nk4dz4fLl5uYnz5rIww=
-github.com/felipeospina21/tuishell v0.8.0/go.mod h1:PdkAVJRM2ug1qKEuW+myzWJy0Q5sILUlU+gMN6sU/h0=
+github.com/felipeospina21/tuishell v0.9.0 h1:ahphIKbowXXX98LkuPrdybaSVRg33vXbeUpTGkoLrt8=
+github.com/felipeospina21/tuishell v0.9.0/go.mod h1:PdkAVJRM2ug1qKEuW+myzWJy0Q5sILUlU+gMN6sU/h0=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S9k=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"os"
 
 	"github.com/felipeospina21/mrglab/internal/logger"
 	"github.com/fsnotify/fsnotify"
@@ -52,7 +53,7 @@ type ThemeOverrides struct {
 	StatusNormal    *string `mapstructure:"status_normal"`
 	StatusLoading   *string `mapstructure:"status_loading"`
 	StatusError     *string `mapstructure:"status_error"`
-	StatusDev       *string `mapstructure:"status_dev"`
+	StatusDemo      *string `mapstructure:"status_demo"`
 	StatusAccent1   *string `mapstructure:"status_accent1"`
 	StatusAccent2   *string `mapstructure:"status_accent2"`
 }
@@ -63,7 +64,7 @@ type Config struct {
 	APIToken string         `mapstructure:"token"`
 	Filters  Filter         `mapstructure:"filters"`
 	Theme    ThemeOverrides `mapstructure:"theme"`
-	DevMode  bool
+	DemoMode bool
 }
 
 // GlobalConfig is the singleton config instance used throughout the application.
@@ -75,7 +76,7 @@ var (
 // Load reads the config file, unmarshals it, and loads environment variables.
 // In dev mode, missing config file and token are tolerated and mock projects are used as fallback.
 func Load(config *Config) error {
-	config.DevMode = isDevMode()
+	config.DemoMode = isDemoMode()
 
 	l, f := logger.New(logger.NewLogger{})
 	defer f.Close()
@@ -89,7 +90,7 @@ func Load(config *Config) error {
 
 	err := viper.ReadInConfig()
 	if err != nil {
-		if config.DevMode {
+		if config.DemoMode {
 			config.BaseURL = "https://gitlab.com"
 			config.Filters.Projects = mockProjects
 			return nil
@@ -106,7 +107,7 @@ func Load(config *Config) error {
 		config.BaseURL = "https://gitlab.com"
 	}
 
-	if config.DevMode {
+	if config.DemoMode {
 		config.Filters.Projects = mockProjects
 	}
 
@@ -117,7 +118,7 @@ func Load(config *Config) error {
 
 	// Env vars
 	err = loadEnvVars(config)
-	if err != nil && !config.DevMode {
+	if err != nil && !config.DemoMode {
 		return err
 	}
 	return nil
@@ -145,13 +146,14 @@ func loadEnvVars(config *Config) error {
 	return nil
 }
 
-var devFlag = flag.Bool("dev", false, "activates dev mode to use mocked data instead of calling api")
+var flags = flag.NewFlagSet("mrglab", flag.ExitOnError)
+var demoFlag = flags.Bool("demo", false, "use mocked data instead of calling api")
 
-func isDevMode() bool {
-	if !flag.Parsed() {
-		flag.Parse()
+func isDemoMode() bool {
+	if !flags.Parsed() {
+		flags.Parse(os.Args[1:])
 	}
-	return *devFlag
+	return *demoFlag
 }
 
 var mockProjects = []Project{

--- a/internal/gitlab/client.go
+++ b/internal/gitlab/client.go
@@ -14,7 +14,7 @@ import (
 type Client struct {
 	gql      *graphql.Client
 	cfg      *config.Config
-	devMode  bool
+	demoMode bool
 	noSleep  bool // skip time.Sleep in dev mode (for tests)
 }
 
@@ -26,8 +26,8 @@ func (c *Client) sleep(d time.Duration) {
 
 // NewClient creates a new GitLab GraphQL client from the given config.
 func NewClient(cfg *config.Config) *Client {
-	if cfg.DevMode {
-		return &Client{cfg: cfg, devMode: true}
+	if cfg.DemoMode {
+		return &Client{cfg: cfg, demoMode: true}
 	}
 
 	httpClient := http.DefaultClient
@@ -40,7 +40,7 @@ func NewClient(cfg *config.Config) *Client {
 	return &Client{
 		gql:     graphql.NewClient(url, httpClient),
 		cfg:     cfg,
-		devMode: false,
+		demoMode: false,
 	}
 }
 

--- a/internal/gitlab/client_test.go
+++ b/internal/gitlab/client_test.go
@@ -7,30 +7,30 @@ import (
 )
 
 func TestNewClientDevMode(t *testing.T) {
-	cfg := &config.Config{DevMode: true}
+	cfg := &config.Config{DemoMode: true}
 	c := NewClient(cfg)
 
-	if !c.devMode {
-		t.Error("NewClient with DevMode=true should set devMode=true")
+	if !c.demoMode {
+		t.Error("NewClient with DemoMode=true should set demoMode=true")
 	}
 	if c.gql != nil {
-		t.Error("NewClient with DevMode=true should not create graphql client")
+		t.Error("NewClient with DemoMode=true should not create graphql client")
 	}
 }
 
 func TestNewClientNonDevMode(t *testing.T) {
 	cfg := &config.Config{
-		DevMode:  false,
+		DemoMode: false,
 		BaseURL:  "https://gitlab.example.com",
 		APIToken: "test-token",
 	}
 	c := NewClient(cfg)
 
-	if c.devMode {
-		t.Error("NewClient with DevMode=false should set devMode=false")
+	if c.demoMode {
+		t.Error("NewClient with DemoMode=false should set demoMode=false")
 	}
 	if c.gql == nil {
-		t.Error("NewClient with DevMode=false should create graphql client")
+		t.Error("NewClient with DemoMode=false should create graphql client")
 	}
 }
 
@@ -52,7 +52,7 @@ func TestProjectFullPath(t *testing.T) {
 }
 
 func devClient() *Client {
-	c := NewClient(&config.Config{DevMode: true})
+	c := NewClient(&config.Config{DemoMode: true})
 	c.noSleep = true
 	return c
 }

--- a/internal/gitlab/createmergerequests.go
+++ b/internal/gitlab/createmergerequests.go
@@ -10,7 +10,7 @@ func (c *Client) CreateMergeRequest(
 	projectID string,
 	input CreateMergeRequestInput,
 ) (CreateMergeRequestResponse, error) {
-	if c.devMode {
+	if c.demoMode {
 		c.sleep(500 * time.Millisecond)
 		return CreateMergeRequestResponse{}, nil
 	}

--- a/internal/gitlab/mergerequests.go
+++ b/internal/gitlab/mergerequests.go
@@ -15,7 +15,7 @@ func (c *Client) GetProjectMergeRequests(
 	projectID string,
 	vars MergeRequestsQueryVariables,
 ) (MergeRequestConnection, error) {
-	if c.devMode {
+	if c.demoMode {
 		c.sleep(1 * time.Second)
 		return mergeRequestConnectionMock, nil
 	}
@@ -37,7 +37,7 @@ func (c *Client) GetMergeRequest(
 	projectID string,
 	vars MergeRequestQueryVariables,
 ) (MergeRequestResponse, error) {
-	if c.devMode {
+	if c.demoMode {
 		c.sleep(800 * time.Millisecond)
 		return mergeRequestResponseMock, nil
 	}
@@ -62,7 +62,7 @@ type ProjectInfo struct {
 
 // GetProjectInfo fetches the project's default branch and MR description template.
 func (c *Client) GetProjectInfo(projectID string) (ProjectInfo, error) {
-	if c.devMode {
+	if c.demoMode {
 		c.sleep(200 * time.Millisecond)
 		return ProjectInfo{DefaultBranch: "main", MergeRequestsTemplate: mrDescriptionTemplatesMock[0].Content}, nil
 	}
@@ -108,7 +108,7 @@ type MRDescriptionTemplate struct {
 // in parallel: project-level files, group-level templates (REST), and the project default
 // description setting. Results are merged and deduplicated by name (project files win).
 func (c *Client) GetMRDescriptionTemplates(projectID string) ([]MRDescriptionTemplate, error) {
-	if c.devMode {
+	if c.demoMode {
 		c.sleep(300 * time.Millisecond)
 		return mrDescriptionTemplatesMock, nil
 	}
@@ -296,7 +296,7 @@ func (c *Client) AcceptMergeRequest(
 	projectID string,
 	input MergeRequestAcceptInput,
 ) (AcceptMergeRequestResponse, error) {
-	if c.devMode {
+	if c.demoMode {
 		c.sleep(500 * time.Millisecond)
 		return AcceptMergeRequestResponse{}, nil
 	}

--- a/internal/gitlab/notes.go
+++ b/internal/gitlab/notes.go
@@ -7,7 +7,7 @@ import (
 
 // CreateNote posts a new comment on a discussion thread.
 func (c *Client) CreateNote(input CreateNoteInput) (CreateNoteResponse, error) {
-	if c.devMode {
+	if c.demoMode {
 		c.sleep(500 * time.Millisecond)
 		return CreateNoteResponse{}, nil
 	}

--- a/internal/gitlab/pipelines.go
+++ b/internal/gitlab/pipelines.go
@@ -10,7 +10,7 @@ func (c *Client) GetProjectPipelines(
 	projectID string,
 	vars PipelinesQueryVariables,
 ) (PipelineConnection, error) {
-	if c.devMode {
+	if c.demoMode {
 		c.sleep(1 * time.Second)
 		return pipelineConnectionMock, nil
 	}
@@ -29,7 +29,7 @@ func (c *Client) GetProjectPipelines(
 
 // RetryPipeline retries all failed jobs in a pipeline.
 func (c *Client) RetryPipeline(id string) (PipelineRetryResponse, error) {
-	if c.devMode {
+	if c.demoMode {
 		c.sleep(500 * time.Millisecond)
 		return PipelineRetryResponse{}, nil
 	}
@@ -49,7 +49,7 @@ func (c *Client) RetryPipeline(id string) (PipelineRetryResponse, error) {
 
 // PlayJob triggers a manual CI job.
 func (c *Client) PlayJob(id string) (*JobPlayResponse, error) {
-	if c.devMode {
+	if c.demoMode {
 		c.sleep(500 * time.Millisecond)
 		return &JobPlayResponse{}, nil
 	}
@@ -69,7 +69,7 @@ func (c *Client) PlayJob(id string) (*JobPlayResponse, error) {
 
 // RetryJob retries a CI job.
 func (c *Client) RetryJob(id string) (*JobRetryResponse, error) {
-	if c.devMode {
+	if c.demoMode {
 		c.sleep(500 * time.Millisecond)
 		return &JobRetryResponse{}, nil
 	}
@@ -89,7 +89,7 @@ func (c *Client) RetryJob(id string) (*JobRetryResponse, error) {
 
 // CancelPipeline cancels a running pipeline.
 func (c *Client) CancelPipeline(id string) (PipelineCancelResponse, error) {
-	if c.devMode {
+	if c.demoMode {
 		c.sleep(500 * time.Millisecond)
 		return PipelineCancelResponse{}, nil
 	}
@@ -109,7 +109,7 @@ func (c *Client) CancelPipeline(id string) (PipelineCancelResponse, error) {
 
 // CancelJob cancels a running CI job.
 func (c *Client) CancelJob(id string) (*JobCancelResponse, error) {
-	if c.devMode {
+	if c.demoMode {
 		c.sleep(500 * time.Millisecond)
 		return &JobCancelResponse{}, nil
 	}

--- a/internal/tui/app/model.go
+++ b/internal/tui/app/model.go
@@ -52,7 +52,7 @@ type Model struct {
 
 // InitMainModel creates and returns the initial application model.
 func InitMainModel(ctx *context.AppContext, cfg *config.Config, client *gitlab.Client) Model {
-	ctx.DevMode = cfg.DevMode
+	ctx.DemoMode = cfg.DemoMode
 
 	theme := tui.BuildTheme(cfg.Theme)
 
@@ -106,7 +106,7 @@ func InitMainModel(ctx *context.AppContext, cfg *config.Config, client *gitlab.C
 		RightPanel:      DetailsPanel{&det},
 		AppIcon:         icon.Gitlab,
 		Keybinds:        projects.Keybinds,
-		DevMode:         cfg.DevMode,
+		DemoMode:         cfg.DemoMode,
 		LeftPanelWidth:  30,
 		LeftPanelStyle:  leftPanelStyle,
 		RightPanelStyle: rightPanelStyle,

--- a/internal/tui/components/statusline/statusline.go
+++ b/internal/tui/components/statusline/statusline.go
@@ -18,7 +18,7 @@ var pkgTheme = style.Theme{
 	StatusNormal:  lipgloss.Color("#6914ff"),
 	StatusLoading: lipgloss.Color("#1A7A94"),
 	StatusError:   lipgloss.Color("#CE3060"),
-	StatusDev:     lipgloss.Color("#4E8212"),
+	StatusDemo:     lipgloss.Color("#4E8212"),
 }
 
 // SetTheme sets the theme used by the statusline package and refreshes derived styles.
@@ -44,7 +44,7 @@ type Model struct {
 
 // New creates a new status bar model.
 func New(ctx *context.AppContext, keybinds help.KeyMap) Model {
-	m := tssl.New(pkgTheme, ctx.DevMode, keybinds)
+	m := tssl.New(pkgTheme, ctx.DemoMode, keybinds)
 	return Model{Model: m, ctx: ctx}
 }
 
@@ -67,8 +67,8 @@ func modeBackground(status string) color.Color {
 		return pkgTheme.StatusLoading
 	case ModesEnum.Error:
 		return pkgTheme.StatusError
-	case ModesEnum.Dev:
-		return pkgTheme.StatusDev
+	case ModesEnum.Demo:
+		return pkgTheme.StatusDemo
 	default:
 		return pkgTheme.StatusNormal
 	}

--- a/internal/tui/components/statusline/statusline_test.go
+++ b/internal/tui/components/statusline/statusline_test.go
@@ -15,7 +15,7 @@ func TestModeBackground(t *testing.T) {
 		{"normal", ModesEnum.Normal, style.StatuslineModeNormal},
 		{"loading", ModesEnum.Loading, style.StatuslineModeLoading},
 		{"error", ModesEnum.Error, style.StatuslineModeError},
-		{"dev", ModesEnum.Dev, style.StatuslineModeDev},
+		{"demo", ModesEnum.Demo, style.StatuslineModeDev},
 		{"unknown falls back to normal", "UNKNOWN", style.StatuslineModeNormal},
 	}
 	for _, tt := range tests {

--- a/internal/tui/keys.go
+++ b/internal/tui/keys.go
@@ -13,7 +13,7 @@ type GlobalKeyMap = tuishell.GlobalKeyMap
 var CommonKeys = tuishell.CommonKeys
 
 // GlobalKeys returns the global keybindings, optionally including dev-mode keys.
-func GlobalKeys(devMode bool) GlobalKeyMap { return tuishell.GlobalKeys(devMode) }
+func GlobalKeys(demoMode bool) GlobalKeyMap { return tuishell.GlobalKeys(demoMode) }
 
 // KeyMatcher returns a predicate that checks if a tea.KeyPressMsg matches a key.Binding.
 func KeyMatcher(msg tea.KeyPressMsg) func(key.Binding) bool { return tuishell.KeyMatcher(msg) }

--- a/internal/tui/theme.go
+++ b/internal/tui/theme.go
@@ -48,7 +48,7 @@ func BuildTheme(overrides config.ThemeOverrides) style.Theme {
 	applyOverride(&t.StatusNormal, overrides.StatusNormal)
 	applyOverride(&t.StatusLoading, overrides.StatusLoading)
 	applyOverride(&t.StatusError, overrides.StatusError)
-	applyOverride(&t.StatusDev, overrides.StatusDev)
+	applyOverride(&t.StatusDemo, overrides.StatusDemo)
 	applyOverride(&t.StatusAccent1, overrides.StatusAccent1)
 	applyOverride(&t.StatusAccent2, overrides.StatusAccent2)
 	return t
@@ -86,7 +86,7 @@ func DefaultTheme() style.Theme {
 		StatusNormal:  lipgloss.Color("#6914ff"),
 		StatusLoading: lipgloss.Color("#1A7A94"),
 		StatusError:   lipgloss.Color("#CE3060"),
-		StatusDev:     lipgloss.Color("#4E8212"),
+		StatusDemo:     lipgloss.Color("#4E8212"),
 		StatusAccent1: lipgloss.Color("#A550DF"),
 		StatusAccent2: lipgloss.Color("#6124DF"),
 	}


### PR DESCRIPTION
## Summary

Replaces the global `-dev` flag with a scoped `flag.FlagSet` using `-demo`, and renames all dev references to demo.

### Changes
- `flag.Bool("dev", ...)` on global FlagSet → scoped `flag.NewFlagSet("mrglab", ...)` with `-demo` flag
- `Config.DevMode` → `DemoMode`, `isDevMode()` → `isDemoMode()`
- `Client.devMode` → `demoMode` (and all API files)
- `ThemeOverrides.StatusDev` → `StatusDemo` (mapstructure: `status_demo`)
- Updated references to tuishell's renamed API (`DemoMode`, `StatusDemo`, `ModesEnum.Demo`)

### Why
The global flag registration caused a panic in tuishell-hub when both mrglab and jiraf were imported (duplicate `dev` flag). Scoped FlagSets avoid the conflict.

### Depends on
- https://github.com/felipeospina21/tuishell/pull/22