### PR TITLE
fix: details panel spinner not showing during fetch

### DIFF
--- a/internal/tui/components/details/details.go
+++ b/internal/tui/components/details/details.go
@@ -109,13 +109,8 @@ func (m *Model) SetViewportViewSize(msg tea.WindowSizeMsg) tea.Cmd {
 	footerHeight := lipgloss.Height(m.FooterView())
 	verticalMarginHeight := headerHeight + footerHeight
 
-	if !m.Ready {
-		m.Viewport = viewport.New(viewport.WithWidth(w), viewport.WithHeight(msg.Height-verticalMarginHeight))
-		m.Ready = true
-	} else {
-		m.Viewport.SetWidth(w)
-		m.Viewport.SetHeight(msg.Height - verticalMarginHeight)
-	}
+	m.Viewport.SetWidth(w)
+	m.Viewport.SetHeight(msg.Height - verticalMarginHeight)
 
 	return nil
 }


### PR DESCRIPTION
## Summary

`SetViewportViewSize` was setting `Ready = true` on the first `WindowSizeMsg`, before the API response arrived. This caused `View()` to render the empty viewport instead of the loading spinner.

## Root cause

When the right panel opens, the shell sends a `WindowSizeMsg` to resize it. `SetViewportViewSize` used `Ready` as a "viewport initialized" flag — on the first call it created a new viewport and set `Ready = true`. But `Ready` is also the flag that `View()` checks to decide whether to show the loader or the viewport content. Setting it to `true` before data arrived meant the loader was never visible.

## Fix

Always resize the existing viewport (already created in `New()`) without touching `Ready`. The flag is now only set to `true` when data actually arrives (`MRDetailsFetchedMsg` / pipeline details).

## What was tested

- Build passes (`GOWORK=off go build ./...`)
- All tests pass (`GOWORK=off go test ./...`)

Closes #90