### PR TITLE
fix: create MR form values cleared before submission

### DIFF
--- a/internal/tui/app/update.go
+++ b/internal/tui/app/update.go
@@ -252,8 +252,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			})
 		}
 		if m.pendingCreateMR {
+			createCmd := m.createMergeRequest()
 			cmds = append(cmds, func() tea.Msg {
-				return tuishell.StartTaskMsg{Cmd: m.createMergeRequest()}
+				return tuishell.StartTaskMsg{Cmd: createCmd}
 			})
 			m.pendingCreateMR = false
 		}


### PR DESCRIPTION
## Summary

The "New Merge Request" form always failed with *"source branch and title are required"* even when both fields were populated.

## Root Cause

In the `SubmitModalMsg` handler, `m.createMergeRequest()` was called inside a deferred closure, but `m.createForm.Reset()` ran immediately after — clearing all form values before the closure ever executed.

## Fix

Evaluate `m.createMergeRequest()` eagerly (before the reset) and store the resulting `tea.Cmd` in a local variable. The closure now captures the pre-computed command instead of reading from the already-reset form.

## Tested

- `make build` passes